### PR TITLE
NeoCsc and NeoExpressBatch Tasks

### DIFF
--- a/src/build-tasks/ContractGenerator.cs
+++ b/src/build-tasks/ContractGenerator.cs
@@ -7,11 +7,11 @@ namespace Neo.BuildTasks
 {
     public static class ContractGenerator
     {
-        // generated from Roslyn C# 3.9 SyntaxFacts.GetKeywordKinds().Select(k => SyntaxFacts.GetText(k))
+        // generated from Roslyn C# 4.1 SyntaxFacts.GetKeywordKinds().Select(k => SyntaxFacts.GetText(k)).OrderBy(k => k)
         static readonly ImmutableHashSet<string> CSHARP_KEYWORDS = ImmutableHashSet.Create("__arglist", "__makeref",
             "__reftype", "__refvalue", "abstract", "add", "alias", "and", "as", "ascending", "assembly", "async",
             "await", "base", "bool", "break", "by", "byte", "case", "catch", "char", "checked", "class", "const",
-            "continue", "data", "decimal", "default", "delegate", "descending", "do", "double", "else", "enum", "equals",
+            "continue", "decimal", "default", "delegate", "descending", "do", "double", "else", "enum", "equals",
             "event", "explicit", "extern", "false", "field", "finally", "fixed", "float", "for", "foreach", "from",
             "get", "global", "goto", "group", "if", "implicit", "in", "init", "int", "interface", "internal", "into",
             "is", "join", "let", "lock", "long", "managed", "method", "module", "nameof", "namespace", "new", "not",

--- a/src/build-tasks/DotNetCliTask.cs
+++ b/src/build-tasks/DotNetCliTask.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Neo.BuildTasks
+{
+    // https://ithrowexceptions.com/2020/08/04/implementing-and-debugging-custom-msbuild-tasks.html
+    // https://maheep.wordpress.com/2017/05/22/msbuild-writing-a-custom-task/
+    // https://natemcmaster.com/blog/2017/07/05/msbuild-task-in-nuget/
+    // https://natemcmaster.com/blog/tags/#msbuild
+
+
+    public class DotNetCliTask : Task
+    {
+        internal enum ToolType { Local, Global }
+
+        public override bool Execute()
+        {
+            var directory = System.IO.Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
+            var package = "neo.express";
+
+            if (FindTool(package, directory, out var toolType, out var version))
+            {
+                Log.LogWarning($"{package} {toolType} tool ({version})");
+                return true;
+            }
+
+            Log.LogError($"Could not locate {package} tool package");
+            return false;
+        }
+
+        internal bool FindTool(string package, string directory, out ToolType toolType, out string version)
+        {
+            if (TryExecute("dotnet", "tool list --local", directory, out var output)
+                && ContainsPackage(output, package, out version))
+            {
+                toolType = ToolType.Local;
+                return true;
+            }
+
+            if (TryExecute("dotnet", "tool list --global", directory, out output)
+                && ContainsPackage(output, package, out version))
+            {
+                toolType = ToolType.Global;
+                return true;
+            }
+
+            toolType = ToolType.Local;
+            version = string.Empty;
+            return false;
+        }
+
+
+        internal bool TryExecute(string command, string arguments, string workingDirectory, out IReadOnlyCollection<string> output)
+        {
+            var results = ProcessRunner.Run(command, arguments, workingDirectory);
+
+            if (results.ExitCode != 0)
+            {
+                Log.LogError($"{command} {arguments} returned {results.ExitCode}");
+                output = Array.Empty<string>();
+                return false;
+            }
+
+            if (results.Error.Any())
+            {
+                foreach (var error in results.Error)
+                {
+                    Log.LogError(error);
+                    output = Array.Empty<string>();
+                    return false;
+                }
+            }
+
+            output = results.Output;
+            return true;
+        }
+
+        internal static bool ContainsPackage(IReadOnlyCollection<string> output, string package, out string version)
+        {
+            foreach (var o in output.Skip(2))
+            {
+                var row = ParseTableRow(o);
+                if (row.Count < 2) continue;
+                if (row[0].Equals(package, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    version = row[1];
+                    return true;
+                }
+            }
+
+            version = string.Empty;
+            return false;
+        }
+
+        internal static IReadOnlyList<string> ParseTableRow(string row)
+        {
+            const string ColumnDelimiter = "      ";
+
+            List<string> columns = new();
+            while (true)
+            {
+                row = row.TrimStart();
+                if (row.Length == 0) break;
+                var index = row.IndexOf(ColumnDelimiter);
+                if (index == -1)
+                {
+                    columns.Add(row);
+                    break;
+                }
+                else
+                {
+                    columns.Add(row.Substring(0, index).Trim());
+                    row = row.Substring(index);
+                }
+            }
+            return columns;
+        }
+
+    }
+}

--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -1,20 +1,24 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.IO;
 using System.Linq;
-using System.Text;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Neo.BuildTasks
 {
+    // https://ithrowexceptions.com/2020/08/04/implementing-and-debugging-custom-msbuild-tasks.html
+    // https://maheep.wordpress.com/2017/05/22/msbuild-writing-a-custom-task/
+    // https://natemcmaster.com/blog/2017/07/05/msbuild-task-in-nuget/
+    // https://natemcmaster.com/blog/tags/#msbuild
+
     public abstract class DotNetToolTask : Task
     {
         internal enum ToolType { Local, Global }
 
         protected abstract string Command { get; }
         protected abstract string PackageId { get; }
-        protected abstract string WorkingDirectory { get; }
+        protected virtual string WorkingDirectory
+            => Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
 
         protected abstract string GetArguments();
 

--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -14,9 +14,6 @@ namespace Neo.BuildTasks
 
         protected abstract string Command { get; }
         protected abstract string PackageId { get; }
-        // protected virtual string WorkingDirectory
-        //     => Path.GetDirectoryName(BuildEngine);
-
 
         ToolType toolType;
 
@@ -33,7 +30,7 @@ namespace Neo.BuildTasks
         {
             foreach (var o in output)
             {
-                Log.LogWarning($"{Command}: {o}");
+                Log.LogMessage(MessageImportance.High, $"{Command}: {o}");
             }
         }
 
@@ -54,7 +51,7 @@ namespace Neo.BuildTasks
                     : $"{Command} {GetArguments()}";
 
                 CommandLine = $"{command} {arguments}";
-                Log.LogWarning($"Running '{command}' '{arguments}' in {directory}");
+                Log.LogMessage(MessageImportance.High, $"Running '{command}' '{arguments}' in {directory}");
 
                 if (TryExecute(command, arguments, directory, out var output))
                 {

--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -21,6 +21,13 @@ namespace Neo.BuildTasks
             => Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
 
         protected abstract string GetArguments();
+        protected virtual void ExecutionSuccess(IReadOnlyCollection<string> output)
+        {
+            foreach (var o in output)
+            {
+                Log.LogWarning($"{Command}: {o}");
+            }
+        }
 
         public override bool Execute()
         {
@@ -31,21 +38,19 @@ namespace Neo.BuildTasks
                 Log.LogWarning($"{packageId} {toolType} tool ({version})");
 
                 var command = toolType == ToolType.Global ? Command : "dotnet";
-                var arguments = toolType == ToolType.Global 
-                    ? GetArguments() 
+                var arguments = toolType == ToolType.Global
+                    ? GetArguments()
                     : $"{Command} {GetArguments()}";
 
                 Log.LogWarning($"Running '{command}' '{arguments}' in {directory}");
 
                 if (TryExecute(command, arguments, directory, out var output))
                 {
-                    foreach (var o in output)
-                    {
-                        Log.LogWarning($"{Command}: {o}");
-                    }
+                    ExecutionSuccess(output);
+                    return true;
                 }
 
-                return true;
+                return false;
             }
 
             Log.LogError($"Could not locate {packageId} tool package");

--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -118,11 +118,6 @@ namespace Neo.BuildTasks
                 return false;
             }
 
-            foreach (var o in results.Output)
-            {
-                Log.LogWarning(o);
-            }
-
             output = results.Output;
             return true;
         }

--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -40,6 +40,7 @@ namespace Neo.BuildTasks
         {
             var packageId = PackageId;
             var directory = WorkingDirectory;
+            Log.LogWarning($"{packageId} {directory}");
             if (FindTool(packageId, directory, out var toolType, out var version))
             {
                 this.toolType = toolType;

--- a/src/build-tasks/DotNetToolTask.cs
+++ b/src/build-tasks/DotNetToolTask.cs
@@ -41,11 +41,12 @@ namespace Neo.BuildTasks
         {
             var packageId = PackageId;
             var directory = WorkingDirectory;
-            Log.LogWarning($"{packageId} {directory}");
+            Log.LogMessage(MessageImportance.Low, $"Searching for {packageId} in '{directory?.ItemSpec}'");
+
             if (FindTool(packageId, directory, out var toolType, out var version))
             {
                 this.toolType = toolType;
-                Log.LogWarning($"{packageId} {toolType} tool ({version})");
+                Log.LogMessage(MessageImportance.High, $"Using {packageId} {toolType} tool ({version})");
 
                 var command = toolType == Neo.BuildTasks.ToolType.Global ? Command : "dotnet";
                 var arguments = toolType == Neo.BuildTasks.ToolType.Global

--- a/src/build-tasks/NeoCsc.cs
+++ b/src/build-tasks/NeoCsc.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Framework;
+
+namespace Neo.BuildTasks
+{
+    public class NeoCsc : DotNetToolTask
+    {
+        const string PACKAGE_ID = "Neo.Compiler.CSharp";
+        const string COMMAND = "nccs";
+        const byte DEFAULT_ADDRESS_VERSION = 53;
+
+        protected override string Command => COMMAND;
+
+        protected override string PackageId => throw new System.NotImplementedException();
+
+        [Required]
+        public ITaskItem[] Files { get; set; } = Array.Empty<ITaskItem>();
+        public ITaskItem? Output { get; set; }
+        public string ContractName { get; set; } = "";
+        public bool Debug { get; set; }
+        public bool Assembly { get; set; }
+        public bool Optimize { get; set; }
+        public bool Inline { get; set; }
+        public byte AddressVersion { get; set; } = DEFAULT_ADDRESS_VERSION;
+
+
+
+        protected override string GetArguments()
+        {
+            var builder = new StringBuilder();
+            foreach (var file in Files)
+            {
+                builder.AppendFormat(" {0}", file.ItemSpec);
+            }
+
+            if (Output is not null)
+            {
+                builder.AppendFormat(" --Output {0}", Output.ItemSpec);
+            }
+
+            if (!string.IsNullOrEmpty(ContractName))
+            {
+                builder.AppendFormat(" --contract-name {0}", ContractName);
+            }
+
+            if (Debug) builder.Append(" --debug");
+            if (Assembly) builder.Append(" --assembly");
+            if (!Optimize) builder.Append(" --no-optimize");
+            if (!Inline) builder.Append(" --no-inline");
+            if (AddressVersion != DEFAULT_ADDRESS_VERSION)
+            {
+                builder.AppendFormat(" --address-version {0}", AddressVersion);
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/build-tasks/NeoCsc.cs
+++ b/src/build-tasks/NeoCsc.cs
@@ -40,7 +40,7 @@ namespace Neo.BuildTasks
 
             if (Output is not null)
             {
-                builder.AppendFormat(" --Output {0}", Output.ItemSpec);
+                builder.AppendFormat(" --output {0}", Output.ItemSpec);
             }
 
             if (!string.IsNullOrEmpty(ContractName))

--- a/src/build-tasks/NeoExpressBatch.cs
+++ b/src/build-tasks/NeoExpressBatch.cs
@@ -43,7 +43,7 @@ namespace Neo.BuildTasks
                 builder.Append(" --reset");
                 if (Checkpoint is not null)
                 {
-                    // builder.AppendFormat(":\"{0}\"", Path.Combine(WorkingDirectory, Checkpoint.ItemSpec));
+                    builder.AppendFormat(":\"{0}\"", Checkpoint.ItemSpec);
                 }
             }
 

--- a/src/build-tasks/NeoExpressBatch.cs
+++ b/src/build-tasks/NeoExpressBatch.cs
@@ -1,15 +1,10 @@
+using System;
 using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 
 namespace Neo.BuildTasks
 {
-    // https://ithrowexceptions.com/2020/08/04/implementing-and-debugging-custom-msbuild-tasks.html
-    // https://maheep.wordpress.com/2017/05/22/msbuild-writing-a-custom-task/
-    // https://natemcmaster.com/blog/2017/07/05/msbuild-task-in-nuget/
-    // https://natemcmaster.com/blog/tags/#msbuild
-
-
     public class NeoExpressBatch : DotNetToolTask
     {
         const string PACKAGE_ID = "Neo.Express";
@@ -17,37 +12,36 @@ namespace Neo.BuildTasks
 
         protected override string Command => COMMAND;
         protected override string PackageId => PACKAGE_ID;
-        protected override string WorkingDirectory
-            => Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
 
         [Required]
-        public string BatchFile { get; set; } = "";
+        public ITaskItem? BatchFile { get; set; }
 
-        public string InputFile { get; set; } = "";
+        public ITaskItem? InputFile { get; set; }
 
         public bool Reset { get; set; }
 
-        public string Checkpoint { get; set; } = "";
+        public ITaskItem? Checkpoint { get; set; }
 
         public bool Trace { get; set; }
 
         protected override string GetArguments()
         {
-            var batchPath = Path.Combine(WorkingDirectory, BatchFile);
-            var inputPath = Path.Combine(WorkingDirectory, 
-                string.IsNullOrEmpty(InputFile) 
-                    ? "default.neo-express" 
-                    : InputFile);
+            if (BatchFile is null) throw new Exception("Missing BatchFile Property");
 
             var builder = new StringBuilder("batch ");
-            builder.AppendFormat("\"{0}\" --input \"{1}\"", batchPath, inputPath);
+            builder.AppendFormat("\"{0}\"", BatchFile.ItemSpec);
+
+            if (InputFile is not null)
+            {
+                builder.AppendFormat(" --input \"{0}\"", InputFile.ItemSpec);
+            }
 
             if (Reset)
             {
                 builder.Append(" --reset");
-                if (!string.IsNullOrEmpty(Checkpoint))
+                if (Checkpoint is not null)
                 {
-                    builder.AppendFormat(":\"{0}\"", Path.Combine(WorkingDirectory, Checkpoint));
+                    builder.AppendFormat(":\"{0}\"", Path.Combine(WorkingDirectory, Checkpoint.ItemSpec));
                 }
             }
 

--- a/src/build-tasks/NeoExpressBatch.cs
+++ b/src/build-tasks/NeoExpressBatch.cs
@@ -41,7 +41,7 @@ namespace Neo.BuildTasks
                 builder.Append(" --reset");
                 if (Checkpoint is not null)
                 {
-                    builder.AppendFormat(":\"{0}\"", Path.Combine(WorkingDirectory, Checkpoint.ItemSpec));
+                    // builder.AppendFormat(":\"{0}\"", Path.Combine(WorkingDirectory, Checkpoint.ItemSpec));
                 }
             }
 

--- a/src/build-tasks/NeoExpressBatch.cs
+++ b/src/build-tasks/NeoExpressBatch.cs
@@ -1,0 +1,59 @@
+using System.IO;
+using System.Text;
+using Microsoft.Build.Framework;
+
+namespace Neo.BuildTasks
+{
+    // https://ithrowexceptions.com/2020/08/04/implementing-and-debugging-custom-msbuild-tasks.html
+    // https://maheep.wordpress.com/2017/05/22/msbuild-writing-a-custom-task/
+    // https://natemcmaster.com/blog/2017/07/05/msbuild-task-in-nuget/
+    // https://natemcmaster.com/blog/tags/#msbuild
+
+
+    public class NeoExpressBatch : DotNetToolTask
+    {
+        const string PACKAGE_ID = "Neo.Express";
+        const string COMMAND = "neoxp";
+
+        protected override string Command => COMMAND;
+        protected override string PackageId => PACKAGE_ID;
+        protected override string WorkingDirectory
+            => Path.GetDirectoryName(BuildEngine.ProjectFileOfTaskNode);
+
+        [Required]
+        public string BatchFile { get; set; } = "";
+
+        public string InputFile { get; set; } = "";
+
+        public bool Reset { get; set; }
+
+        public string Checkpoint { get; set; } = "";
+
+        public bool Trace { get; set; }
+
+        protected override string GetArguments()
+        {
+            var batchPath = Path.Combine(WorkingDirectory, BatchFile);
+            var inputPath = Path.Combine(WorkingDirectory, 
+                string.IsNullOrEmpty(InputFile) 
+                    ? "default.neo-express" 
+                    : InputFile);
+
+            var builder = new StringBuilder("batch ");
+            builder.AppendFormat("\"{0}\" --input \"{1}\"", batchPath, inputPath);
+
+            if (Reset)
+            {
+                builder.Append(" --reset");
+                if (!string.IsNullOrEmpty(Checkpoint))
+                {
+                    builder.AppendFormat(":\"{0}\"", Path.Combine(WorkingDirectory, Checkpoint));
+                }
+            }
+
+            if (Trace) { builder.Append(" --trace"); }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/src/build-tasks/NeoExpressBatch.cs
+++ b/src/build-tasks/NeoExpressBatch.cs
@@ -24,6 +24,8 @@ namespace Neo.BuildTasks
 
         public bool Trace { get; set; }
 
+        public bool StackTrace { get; set; }
+
         protected override string GetArguments()
         {
             if (BatchFile is null) throw new Exception("Missing BatchFile Property");
@@ -46,6 +48,7 @@ namespace Neo.BuildTasks
             }
 
             if (Trace) { builder.Append(" --trace"); }
+            if (StackTrace) { builder.Append(" --stack-trace"); }
 
             return builder.ToString();
         }

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -28,11 +28,24 @@ namespace Neo.BuildTasks
                 EnableRaisingEvents = true,
             };
 
-            ConcurrentQueue<string> output = new();
-            process.OutputDataReceived += (sender, args) => { if (args.Data != null) { output.Enqueue(args.Data); } };
+            Queue<string> output = new();
+            process.OutputDataReceived += (sender, args) => 
+            { 
+                if (args.Data != null) 
+                { 
+                    lock (output) { output.Enqueue(args.Data); }
+                }
+            };
 
-            ConcurrentQueue<string> error = new();
-            process.ErrorDataReceived += (sender, args) => { if (args.Data != null) { error.Enqueue(args.Data); } };
+            Queue<string> error = new();
+            process.ErrorDataReceived += (sender, args) =>
+            { 
+                if (args.Data != null) 
+                { 
+                    lock (error) { error.Enqueue(args.Data); }
+                }
+            };
+
 
             ManualResetEvent completeEvent = new(false);
 

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Neo.BuildTasks
+{
+    // https://github.com/jamesmanning/RunProcessAsTask
+    class ProcessRunner
+    {
+        public record struct Results(int ExitCode, IReadOnlyCollection<string> Output, IReadOnlyCollection<string> Error);
+
+        public static Results Run(string command, string arguments, string workingDirectory = "")
+        {
+            var startInfo = new System.Diagnostics.ProcessStartInfo(command, arguments)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                WorkingDirectory = string.IsNullOrEmpty(workingDirectory) ? null : workingDirectory,
+            };
+
+            var process = new System.Diagnostics.Process
+            {
+                StartInfo = startInfo,
+                EnableRaisingEvents = true,
+            };
+
+            ConcurrentQueue<string> output = new();
+            process.OutputDataReceived += (sender, args) => { if (args.Data != null) { output.Enqueue(args.Data); } };
+
+            ConcurrentQueue<string> error = new();
+            process.ErrorDataReceived += (sender, args) => { if (args.Data != null) { error.Enqueue(args.Data); } };
+
+            ManualResetEvent completeEvent = new(false);
+
+            process.Exited += (_, _) => { completeEvent.Set(); };
+
+            if (!process.Start()) throw new Exception("Process failed to start");
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            completeEvent.WaitOne();
+
+            while (!process.HasExited)
+            {
+                Thread.Sleep(50);
+            }
+
+            return new Results(process.ExitCode, output, error);
+        }
+    }
+}

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -38,6 +38,7 @@ namespace Neo.BuildTasks
 
             process.Exited += (_, _) => 
             { 
+                process.WaitForExit();
                 while (!process.HasExited)
                 {
                     Thread.Sleep(50);

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -11,7 +11,7 @@ namespace Neo.BuildTasks
     {
         public record struct Results(int ExitCode, IReadOnlyCollection<string> Output, IReadOnlyCollection<string> Error);
 
-        public static Results Run(string command, string arguments, string workingDirectory = "")
+        public static Results Run(string command, string arguments, string? workingDirectory = null)
         {
             var startInfo = new System.Diagnostics.ProcessStartInfo(command, arguments)
             {

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -36,7 +36,15 @@ namespace Neo.BuildTasks
 
             ManualResetEvent completeEvent = new(false);
 
-            process.Exited += (_, _) => { completeEvent.Set(); };
+            process.Exited += (_, _) => 
+            { 
+                while (!process.HasExited)
+                {
+                    Thread.Sleep(50);
+                }
+                
+                completeEvent.Set(); 
+            };
 
             if (!process.Start()) throw new Exception("Process failed to start");
             process.BeginOutputReadLine();

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>neo-build-tasks</AssemblyName>
     <!-- Change the default location where NuGet will put the build output -->
     <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <!-- Suppresses the warnings about the package not having assemblies in lib/*/.dll.-->
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageId>Neo.BuildTasks</PackageId>

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.5.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.5.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <PackageReference Update="@(PackageReference)" PrivateAssets="all" />
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -74,7 +74,7 @@
   </Target>
 
   <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
-    <Message Importance="High" Text="Run $(NeoExpressNormalizedBatchFile)" />
+    <Message Importance="High" Text="NeoExpress Batch -> $(NeoExpressNormalizedBatchFile)" />
   </Target>
 
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -68,9 +68,6 @@
       Reset="true" 
       WorkingDirectory="$(MSBuildProjectDirectory)" />
     <Touch Files="$(NeoExpressTouchFile)" AlwaysCreate="true" />
-  </Target>
-
-  <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
     <Message Importance="High" Text="NeoExpress Batch -> $(NeoExpressNormalizedBatchFile)" />
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -58,8 +58,8 @@
       <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
       <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
     </PropertyGroup>
-    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressBatchFile)"/>
-    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressNormalizedBatchFile)"/>
+    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressBatchFile))"/>
+    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressNormalizedBatchFile))"/>
   </Target>
 
   <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -58,6 +58,7 @@
       <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
       <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
     </PropertyGroup>
+    <Message Importance="High" Text="$(NeoExpressBatchFile)"/>
     <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressBatchFile)))"/>
     <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressNormalizedBatchFile)))"/>
   </Target>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -81,7 +81,7 @@
 
   <Target Name="BeforeNeoContractInterface" BeforeTargets="ExecuteNeoContractInterface" Condition="'$(NeoContractManifest)'!=''">
     <PropertyGroup>
-      <NeoContractInterfaceBaseName>$([System.IO.Path]::GetFileNameWithoutExtension('$(NeoContractManifest)'))</NeoContractInterfaceBaseName>
+      <NeoContractInterfaceBaseName>$([System.IO.Path]::GetFileName('$(NeoContractManifest)'))</NeoContractInterfaceBaseName>
       <!-- <NeoContractManifestPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(NeoContractManifest)'))</NeoContractManifestPath> -->
       <NeoContractInterfacePath>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(NeoContractInterfaceBaseName).cs'))</NeoContractInterfacePath>
     </PropertyGroup>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -8,76 +8,7 @@
   </PropertyGroup>
 
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoContractInterface"/>
-
-  <PropertyGroup>
-    <NeoContractExt>.nef</NeoContractExt>
-    <NeoManifestExt>.manifest.json</NeoManifestExt>
-    <NeoDebugInfoExt>.nefdbgnfo</NeoDebugInfoExt>
-    <NccsOutputPath>bin\sc\</NccsOutputPath>
-    <TargetNccsOutputPath Condition="'$(NccsOutputPath)' != ''">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(NccsOutputPath)'))</TargetNccsOutputPath>
-    <TargetNeoContractFileName Condition="'$(TargetNeoContractName)' != ''">$(TargetNeoContractName)$(NeoContractExt)</TargetNeoContractFileName>
-    <TargetNeoContractPath Condition="'$(TargetNeoContractFileName)' != ''">$(TargetNccsOutputPath)$(TargetNeoContractFileName)</TargetNeoContractPath>
-    <TargetNeoManifestFileName Condition="'$(TargetNeoContractName)' != ''">$(TargetNeoContractName)$(NeoManifestExt)</TargetNeoManifestFileName>
-    <TargetNeoManifestPath Condition="'$(TargetNeoManifestFileName)' != ''">$(TargetNccsOutputPath)$(TargetNeoManifestFileName)</TargetNeoManifestPath>
-    <TargetNeoDebugInfoFileName Condition="'$(TargetNeoContractName)' != ''">$(TargetNeoContractName)$(NeoDebugInfoExt)</TargetNeoDebugInfoFileName>
-    <TargetNeoDebugInfoPath Condition="'$(TargetNeoDebugInfoFileName)' != ''">$(TargetNccsOutputPath)$(TargetNeoDebugInfoFileName)</TargetNeoDebugInfoPath>
-  </PropertyGroup>
-
-  <Target Name="NccsBuild" AfterTargets="Build" Inputs="$(MSBuildProjectFullPath);@(Compile);" Outputs="$(TargetNeoContractPath);$(TargetNeoManifestPath);">
-    <PropertyGroup>
-      <_NccsDebugArguments Condition="'$(Configuration)'=='Debug'">--debug --no-optimize</_NccsDebugArguments>
-      <_NccsDebugArguments Condition="'$(Configuration)'!='Debug'"></_NccsDebugArguments>
-    </PropertyGroup>
-    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet nccs $(_NccsDebugArguments) $(MSBuildProjectFullPath)" />
-  </Target>
-
-  <Target Name="RunNeoExpressBatch" AfterTargets="Build" Inputs="$(TargetNeoContractPath);$(NeoExpressBatch)" Outputs="$(IntermediateOutputPath)neoxp">
-    <PropertyGroup>
-      <_NeoExpressFilePath Condition="'$(NeoExpressFile)' != ''">$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(NeoExpressFile)'))</_NeoExpressFilePath>
-      <_NeoExpressParameter Condition="'$(_NeoExpressFilePath)' != ''">--input $(_NeoExpressFilePath)</_NeoExpressParameter>
-      <_NeoExpressBatchFilePath Condition="'$(NeoExpressBatch)' != ''">$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(NeoExpressBatch)'))</_NeoExpressBatchFilePath>
-      <_NeoExpressBatchFileDirectory Condition="'$(_NeoExpressBatchFilePath)' != ''">$([System.IO.Path]::GetDirectoryName('$(_NeoExpressBatchFilePath)'))</_NeoExpressBatchFileDirectory>
-    </PropertyGroup>
-
-    <Exec Command="dotnet neoxp batch $(_NeoExpressBatchFilePath) --reset $(_NeoExpressParameter)" WorkingDirectory="$(_NeoExpressBatchFileDirectory)" />
-    <Touch Files="$(IntermediateOutputPath)neoxp" AlwaysCreate="true" />
-  </Target>
-
-  <Target Name="GetTargetNeoContract" Returns="@(TargetNeoContract)">
-    <ItemGroup>
-      <TargetNeoContract Include="$(TargetNeoContractPath)">
-        <Name>$(TargetNeoContractName)</Name>
-        <ManifestPath>$(TargetNeoManifestPath)</ManifestPath>
-      </TargetNeoContract>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="GenerateContractInterface" BeforeTargets="ResolveProjectReferences" Condition="'@(NeoContractReference->Count())' &gt; 0">
-    <ItemGroup>
-      <ProjectReference Include="@(NeoContractReference)">
-        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      </ProjectReference>
-    </ItemGroup>
-
-    <MSBuild Projects="@(NeoContractReference)" Targets="GetTargetNeoContract">
-      <Output TaskParameter="TargetOutputs" ItemName="TargetNeoContract" />
-    </MSBuild>
-
-    <ItemGroup>
-      <NeoContractManifest Include="@(TargetNeoContract->Metadata('ManifestPath'))" >
-        <OutputFile>$(IntermediateOutputPath)@(TargetNeoContract->Metadata('Name')).contract-interface.cs</OutputFile>
-      </NeoContractManifest>
-    </ItemGroup>
-
-    <NeoContractInterface
-      ManifestFile="@(NeoContractManifest)"
-      OutputFile="@(NeoContractManifest->Metadata('OutputFile'))"
-      RootNamespace="$(RootNamespace)"/>
-
-    <ItemGroup>
-      <Compile Include="@(NeoContractManifest->Metadata('OutputFile'))" />
-    </ItemGroup>
-
-  </Target>
+  <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoCsc"/>
+  <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoExpressBatch"/>
 
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -53,5 +53,21 @@
     <Message Importance="High" Text="$(NeoContractName) -&gt; $(NeoCscContractPath)" />
   </Target>
 
+  <Target Name="BeforeExecuteNeoExpressBatch" BeforeTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
+    <PropertyGroup>
+      <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).touch'))</NeoExpressTouchFile>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"
+    Inputs="@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
+
+    <NeoExpressBatch BatchFile="$(NeoExpressBatchFile)" Reset="true" />
+    <Touch Files="$(NeoExpressTouchFile)" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
+    <Message Importance="High" Text="Run $(NeoExpressBatchFile)" />
+  </Target>
 
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -88,15 +88,15 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GenerateNeoContractInterface" BeforeTargets="ResolveProjectReferences" Condition="'@(NeoContractInterface)'!=''">
+  <Target Name="GenerateNeoContractInterface" BeforeTargets="ResolveProjectReferences" Condition="'@(NeoContractReference)'!=''">
 
     <ItemGroup>
-      <ProjectReference Include="@(NeoContractInterface)">
+      <ProjectReference Include="@(NeoContractReference)">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       </ProjectReference>
     </ItemGroup>
 
-    <MSBuild Projects="@(NeoContractInterface)" Targets="GetNeoContractInfo">
+    <MSBuild Projects="@(NeoContractReference)" Targets="GetNeoContractInfo">
       <Output TaskParameter="TargetOutputs" ItemName="NeoContractInfo" />
     </MSBuild>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -58,8 +58,8 @@
       <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
       <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
     </PropertyGroup>
-    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressBatchFile))"/>
-    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressNormalizedBatchFile))"/>
+    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressBatchFile)))"/>
+    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressNormalizedBatchFile)))"/>
   </Target>
 
   <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -74,7 +74,7 @@
   </Target>
 
   <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
-    <Message Importance="High" Text="Run $(NeoExpressBatchFile)" />
+    <Message Importance="High" Text="Run $(NeoExpressNormalizedBatchFile)" />
   </Target>
 
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -48,5 +48,10 @@
       Optimize="$(Optimize)"
     />
   </Target>
-  
+
+  <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
+    <Message Importance="High" Text="$(NeoContractOutput) -&gt; $(NeoCscContractPath)" />
+  </Target>
+
+
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -11,12 +11,10 @@
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoCsc"/>
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoExpressBatch"/>
 
-  <Target Name="BeforeExecuteNeoCsc" BeforeTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
+  <Target Name="BeforeExecuteNeoCsc" BeforeTargets="ExecuteNeoCsc" Condition="'$(NeoContractName)'!=''">
     <PropertyGroup>
-      <NeoContractName Condition="'$(NeoContractName)' == ''">$(TargetName)</NeoContractName>
-
-      <NeoCscOutputFolder Condition="'$(NeoContractOutput)' == ''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), 'bin\sc'))</NeoCscOutputFolder>
-      <NeoCscOutputFolder Condition="'$(NeoContractOutput)' != ''">$(NeoContractOutput)</NeoCscOutputFolder>
+      <NeoCscOutputFolder Condition="'$(NeoContractOutput)'==''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), 'bin\sc'))</NeoCscOutputFolder>
+      <NeoCscOutputFolder Condition="'$(NeoContractOutput)'!=''">$(NeoContractOutput)</NeoCscOutputFolder>
 
       <NeoCscContractPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).nef'))</NeoCscContractPath>
       <NeoCscManifestPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).manifest.json'))</NeoCscManifestPath>
@@ -35,7 +33,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ExecuteNeoCsc" AfterTargets="Compile" Condition="'$(NeoContract)'=='true'"
+  <Target Name="ExecuteNeoCsc" AfterTargets="Compile" Condition="'$(NeoContractName)'!=''"
     Inputs="$(MSBuildProjectFullPath);@(Compile);" Outputs="@(NeoCscOutput)">
 
     <NeoCsc 
@@ -49,7 +47,7 @@
       WorkingDirectory="$(MSBuildProjectDirectory)"/>
   </Target>
 
-  <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
+  <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContractName)'!=''">
     <Message Importance="High" Text="$(NeoContractName) -&gt; $(NeoCscContractPath)" />
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -56,17 +56,18 @@
   <Target Name="BeforeExecuteNeoExpressBatch" BeforeTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
     <PropertyGroup>
       <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
+      <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
     </PropertyGroup>
   </Target>
 
-  <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"
-    Inputs="@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
+  <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressNormalizedBatchFile)'!=''"
+    Inputs="@(NeoCscOutput);$(NeoExpressNormalizedBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
 
-    <NeoExpressBatch BatchFile="$(NeoExpressBatchFile)" Reset="true" />
+    <NeoExpressBatch BatchFile="$(NeoExpressNormalizedBatchFile)" Reset="true" />
     <Touch Files="$(NeoExpressTouchFile)" AlwaysCreate="true" />
   </Target>
 
-  <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
+  <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressNormalizedBatchFile)'!=''">
     <Message Importance="High" Text="Run $(NeoExpressBatchFile)" />
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -11,10 +11,8 @@
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoCsc"/>
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoExpressBatch"/>
 
-  <Target Name="BeforeExecuteNeoCsc" BeforeTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
+  <Target Name="BeforeExecuteNeoCsc" BeforeTargets="ExecuteNeoCsc" Condition="'$(NeoContractName)'!=''">
     <PropertyGroup>
-      <NeoContractName Condition="'$(NeoContractName)' == ''">$(TargetName)</NeoContractName>
-
       <NeoCscOutputFolder Condition="'$(NeoContractOutput)' == ''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), 'bin\sc'))</NeoCscOutputFolder>
       <NeoCscOutputFolder Condition="'$(NeoContractOutput)' != ''">$(NeoContractOutput)</NeoCscOutputFolder>
 
@@ -35,7 +33,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ExecuteNeoCsc" AfterTargets="Compile" Condition="'$(NeoContract)'=='true'"
+  <Target Name="ExecuteNeoCsc" AfterTargets="Compile" Condition="'$(NeoContractName)'!=''"
     Inputs="$(MSBuildProjectFullPath);@(Compile);" Outputs="@(NeoCscOutput)">
 
     <NeoCsc 
@@ -49,7 +47,7 @@
       WorkingDirectory="$(MSBuildProjectDirectory)"/>
   </Target>
 
-  <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
+  <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContractName)'!=''">
     <Message Importance="High" Text="$(NeoContractName) -&gt; $(NeoCscContractPath)" />
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -50,8 +50,7 @@
   </Target>
 
   <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
-    <Message Importance="High" Text="$(NeoContractOutput) -&gt; $(NeoCscContractPath)" />
+    <Message Importance="High" Text="$(NeoContractName) -&gt; $(NeoCscContractPath)" />
   </Target>
-
 
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -55,7 +55,7 @@
 
   <Target Name="BeforeExecuteNeoExpressBatch" BeforeTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
     <PropertyGroup>
-      <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).touch'))</NeoExpressTouchFile>
+      <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
     </PropertyGroup>
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -58,9 +58,6 @@
       <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
       <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
     </PropertyGroup>
-    <Message Importance="High" Text="$(NeoExpressBatchFile)"/>
-    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressBatchFile)))"/>
-    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressNormalizedBatchFile)))"/>
   </Target>
 
   <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -79,4 +79,23 @@
     <Message Importance="High" Text="NeoExpress Batch -> $(NeoExpressNormalizedBatchFile)" />
   </Target>
 
+  <Target Name="BeforeNeoContractInterface" BeforeTargets="ExecuteNeoContractInterface" Condition="'$(NeoContractManifest)'!=''">
+    <PropertyGroup>
+      <NeoContractInterfaceBaseName>$([System.IO.Path]::GetFileNameWithoutExtension('$(NeoContractManifest)'))</NeoContractInterfaceBaseName>
+      <!-- <NeoContractManifestPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(NeoContractManifest)'))</NeoContractManifestPath> -->
+      <NeoContractInterfacePath>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(NeoContractInterfaceBaseName).cs'))</NeoContractInterfacePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Compile Include="$(NeoContractInterfacePath)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExecuteNeoContractInterface" BeforeTargets="ResolveProjectReferences" Condition="'$(NeoContractManifest)'!=''"
+          Inputs="$(NeoContractManifest);$(MSBuildProjectFullPath)"
+          Outputs="$(NeoContractInterfacePath)">
+    <NeoContractInterface ManifestFile="$(NeoContractManifest)" OutputFile="$(NeoContractInterfacePath)" RootNamespace="$(RootNamespace)"/>
+  </Target>
+
+
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -11,4 +11,42 @@
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoCsc"/>
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoExpressBatch"/>
 
+  <Target Name="BeforeExecuteNeoCsc" BeforeTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
+    <PropertyGroup>
+      <NeoContractName Condition="'$(NeoContractName)' == ''">$(TargetName)</NeoContractName>
+
+      <NeoCscOutputFolder Condition="'$(NeoContractOutput)' == ''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), 'bin\sc'))</NeoCscOutputFolder>
+      <NeoCscOutputFolder Condition="'$(NeoContractOutput)' != ''">$(NeoContractOutput)</NeoCscOutputFolder>
+
+      <NeoCscContractPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).nef'))</NeoCscContractPath>
+      <NeoCscManifestPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).manifest.json'))</NeoCscManifestPath>
+      <NeoCscDebugInfoPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).nefdbgnfo'))</NeoCscDebugInfoPath>
+      <NeoCscAssemblyPath>$([MSBuild]::NormalizePath($(NeoCscOutputFolder), '$(NeoContractName).asm'))</NeoCscAssemblyPath>
+
+      <NeoCscOptimize>true</NeoCscOptimize>
+      <NeoCscOptimize Condition="'$(Configuration)'=='Debug'">false</NeoCscOptimize>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <NeoCscOutput Include="$(NeoCscContractPath)" />
+      <NeoCscOutput Include="$(NeoCscManifestPath)" />
+      <NeoCscOutput Include="$(NeoCscDebugInfoPath)" Condition="'$(DebugSymbols)'=='true'" />
+      <NeoCscOutput Include="$(NeoCscAssemblyPath)" Condition="'$(NeoContractAssembly)'=='true'"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ExecuteNeoCsc" AfterTargets="Compile" Condition="'$(NeoContract)'=='true'"
+    Inputs="$(MSBuildProjectFullPath);@(Compile);" Outputs="@(NeoCscOutput)">
+
+    <NeoCsc 
+      Files="$(MSBuildProjectFullPath)"
+      Output="$(NeoContractOutput)"
+      ContractName="$(NeoContractName)"
+      Assembly="$(NeoContractAssembly)"
+      Debug="$(DebugSymbols)"
+      Inline="$(Optimize)"
+      Optimize="$(Optimize)"
+    />
+  </Target>
+  
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -87,9 +87,9 @@
       </NeoContractInfo>
     </ItemGroup>
   </Target>
-  
+
   <Target Name="GenerateNeoContractInterface" BeforeTargets="ResolveProjectReferences" Condition="'@(NeoContractInterface)'!=''">
-    <Message Importance="High" Text="@(NeoContractInterface)" />
+
     <ItemGroup>
       <ProjectReference Include="@(NeoContractInterface)">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -46,7 +46,7 @@
       Debug="$(DebugSymbols)"
       Inline="$(Optimize)"
       Optimize="$(Optimize)"
-    />
+      WorkingDirectory="$(MSBuildProjectDirectory)"/>
   </Target>
 
   <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
@@ -66,7 +66,10 @@
   <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"
     Inputs="@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
 
-    <NeoExpressBatch BatchFile="$(NeoExpressNormalizedBatchFile)" Reset="true" />
+    <NeoExpressBatch 
+      BatchFile="$(NeoExpressNormalizedBatchFile)" 
+      Reset="true" 
+      WorkingDirectory="$(MSBuildProjectDirectory)" />
     <Touch Files="$(NeoExpressTouchFile)" AlwaysCreate="true" />
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -61,9 +61,18 @@
   <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"
     Inputs="@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
 
+    <PropertyGroup>
+      <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
+      <NeoExpressBatchReset>true</NeoExpressBatchReset>
+      <NeoExpressBatchReset Condition="'(NeoExpressBatchNoReset)'=='true'">false</NeoExpressBatchReset>
+    </PropertyGroup>
+
     <NeoExpressBatch 
       BatchFile="$(NeoExpressNormalizedBatchFile)" 
-      Reset="true" 
+      InputFile="$(NeoExpressBatchInputFile)"
+      Reset="$(NeoExpressBatchReset)"
+      Checkpoint="$(NeoExpressBatchCheckpoint)"
+      Trace="$(NeoExpressBatchTrace)"
       StackTrace="$(NeoExpressBatchStackTrace)"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
     <Touch Files="$(NeoExpressTouchFile)" AlwaysCreate="true" />

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -11,8 +11,10 @@
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoCsc"/>
   <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoExpressBatch"/>
 
-  <Target Name="BeforeExecuteNeoCsc" BeforeTargets="ExecuteNeoCsc" Condition="'$(NeoContractName)'!=''">
+  <Target Name="BeforeExecuteNeoCsc" BeforeTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
     <PropertyGroup>
+      <NeoContractName Condition="'$(NeoContractName)' == ''">$(TargetName)</NeoContractName>
+
       <NeoCscOutputFolder Condition="'$(NeoContractOutput)' == ''">$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), 'bin\sc'))</NeoCscOutputFolder>
       <NeoCscOutputFolder Condition="'$(NeoContractOutput)' != ''">$(NeoContractOutput)</NeoCscOutputFolder>
 
@@ -33,7 +35,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ExecuteNeoCsc" AfterTargets="Compile" Condition="'$(NeoContractName)'!=''"
+  <Target Name="ExecuteNeoCsc" AfterTargets="Compile" Condition="'$(NeoContract)'=='true'"
     Inputs="$(MSBuildProjectFullPath);@(Compile);" Outputs="@(NeoCscOutput)">
 
     <NeoCsc 
@@ -47,7 +49,7 @@
       WorkingDirectory="$(MSBuildProjectDirectory)"/>
   </Target>
 
-  <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContractName)'!=''">
+  <Target Name="AfterExecuteNeoCsc" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoContract)'=='true'">
     <Message Importance="High" Text="$(NeoContractName) -&gt; $(NeoCscContractPath)" />
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -58,16 +58,18 @@
       <NeoExpressTouchFile>$([MSBuild]::NormalizePath($(IntermediateOutputPath), '$(NeoExpressBatchFile).neoxp.touch'))</NeoExpressTouchFile>
       <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
     </PropertyGroup>
+    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressBatchFile)"/>
+    <Message Importance="High" Text="$([MSBuild]::NormalizePath($(NeoExpressNormalizedBatchFile)"/>
   </Target>
 
-  <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressNormalizedBatchFile)'!=''"
-    Inputs="@(NeoCscOutput);$(NeoExpressNormalizedBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
+  <Target Name="ExecuteNeoExpressBatch" AfterTargets="ExecuteNeoCsc" Condition="'$(NeoExpressBatchFile)'!=''"
+    Inputs="@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
 
     <NeoExpressBatch BatchFile="$(NeoExpressNormalizedBatchFile)" Reset="true" />
     <Touch Files="$(NeoExpressTouchFile)" AlwaysCreate="true" />
   </Target>
 
-  <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressNormalizedBatchFile)'!=''">
+  <Target Name="AfterExecuteNeoExpressBatch" AfterTargets="ExecuteNeoExpressBatch" Condition="'$(NeoExpressBatchFile)'!=''">
     <Message Importance="High" Text="Run $(NeoExpressBatchFile)" />
   </Target>
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -66,6 +66,7 @@
     <NeoExpressBatch 
       BatchFile="$(NeoExpressNormalizedBatchFile)" 
       Reset="true" 
+      StackTrace="$(NeoExpressBatchStackTrace)"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
     <Touch Files="$(NeoExpressTouchFile)" AlwaysCreate="true" />
     <Message Importance="High" Text="NeoExpress Batch -> $(NeoExpressNormalizedBatchFile)" />

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -79,23 +79,45 @@
     <Message Importance="High" Text="NeoExpress Batch -> $(NeoExpressNormalizedBatchFile)" />
   </Target>
 
-  <Target Name="BeforeNeoContractInterface" BeforeTargets="ExecuteNeoContractInterface" Condition="'$(NeoContractManifest)'!=''">
-    <PropertyGroup>
-      <NeoContractInterfaceBaseName>$([System.IO.Path]::GetFileName('$(NeoContractManifest)'))</NeoContractInterfaceBaseName>
-      <!-- <NeoContractManifestPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '$(NeoContractManifest)'))</NeoContractManifestPath> -->
-      <NeoContractInterfacePath>$([MSBuild]::NormalizePath('$(IntermediateOutputPath)', '$(NeoContractInterfaceBaseName).cs'))</NeoContractInterfacePath>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <Compile Include="$(NeoContractInterfacePath)" />
+  <Target Name="GetNeoContractInfo" Returns="@(NeoContractInfo)" >
+    <ItemGroup Condition="'$(NeoContractName)'!=''" >
+      <NeoContractInfo Include="$(NeoContractName)">
+        <NefPath>$(NeoCscContractPath)</NefPath>
+        <ManifestPath>$(NeoCscManifestPath)</ManifestPath>
+      </NeoContractInfo>
     </ItemGroup>
   </Target>
+  
+  <Target Name="GenerateNeoContractInterface" BeforeTargets="ResolveProjectReferences" Condition="'@(NeoContractInterface)'!=''">
+    <Message Importance="High" Text="@(NeoContractInterface)" />
+    <ItemGroup>
+      <ProjectReference Include="@(NeoContractInterface)">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      </ProjectReference>
+    </ItemGroup>
 
-  <Target Name="ExecuteNeoContractInterface" BeforeTargets="ResolveProjectReferences" Condition="'$(NeoContractManifest)'!=''"
-          Inputs="$(NeoContractManifest);$(MSBuildProjectFullPath)"
-          Outputs="$(NeoContractInterfacePath)">
-    <NeoContractInterface ManifestFile="$(NeoContractManifest)" OutputFile="$(NeoContractInterfacePath)" RootNamespace="$(RootNamespace)"/>
+    <MSBuild Projects="@(NeoContractInterface)" Targets="GetNeoContractInfo">
+      <Output TaskParameter="TargetOutputs" ItemName="NeoContractInfo" />
+    </MSBuild>
+
+    <ItemGroup>
+      <NeoContractManifest Include="@(NeoContractInfo)" >
+        <ManifestFile>@(NeoContractInfo->Metadata('ManifestPath'))</ManifestFile>
+        <OutputFile>$(IntermediateOutputPath)@(NeoContractInfo).contract-interface.cs</OutputFile>
+      </NeoContractManifest>
+    </ItemGroup>
+
+    <NeoContractInterface
+      ManifestFile="@(NeoContractManifest->Metadata('ManifestFile'))"
+      OutputFile="$(IntermediateOutputPath)@(NeoContractInfo).contract-interface.cs"
+      RootNamespace="$(RootNamespace)"/>
+
+    <ItemGroup>
+      <Compile Include="@(NeoContractManifest->Metadata('OutputFile'))" />
+    </ItemGroup>
+
+    <Message Importance="High" Text="NeoContractInterface @(NeoContractManifest) -> @(NeoContractManifest->Metadata('OutputFile'))" />
+
   </Target>
-
 
 </Project>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -53,4 +53,5 @@
     <Message Importance="High" Text="$(NeoContractName) -&gt; $(NeoCscContractPath)" />
   </Target>
 
+
 </Project>


### PR DESCRIPTION
* Adds abstract DotNetToolTask for automatically detecting if a specified .NET tool is installed globally or locally
* Adds NeoCsc task for invoking the Neo C# compiler
* Adds NeoExpressBatch task for invoking NeoExpress `batch` command
* Updated to MSBuild 17.0 dependencies since Neo smart contracts require .NET 6 as of 3.1


