### PR TITLE
Updates for Neo 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ may not exactly match a publicly released version.
 
 ## [Unreleased]
 
+### Added
+
+* NeoCsc and NeoExpressBatch MSBuild tasks (plus .targets file)
+* Abstract DotNetToolTask for invoking dotnet tools installed globally or locally
+* `ScriptBuilder.EmitContractCall` extension methods
+* `NativeContracts` static class 
+  * `NeoToken` and `GasToken` contract hashes
+* `Nep17Token` and `NeoToken` contract interfaces for use with `NeoTestHarness`
+
 ### Changed
 
 * Use ContractParameterParser.ConvertObject to convert object instances to ContractParameter in NeoTestHarness.Extensions.CreateScript (#20)

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="ngd-ent-artifacts" value="https://pkgs.dev.azure.com/ngdenterprise/Build/_packaging/public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NeoVersion>3.1.0</NeoVersion>
-    <BlockchainToolkitLibraryVersion>3.1.35</BlockchainToolkitLibraryVersion>
+    <NeoVersion>3.2.1</NeoVersion>
+    <BlockchainToolkitLibraryVersion>3.2.49-preview</BlockchainToolkitLibraryVersion>
     <BlockchainToolkitLibraryLocalPath>..\..\..\lib-bctk</BlockchainToolkitLibraryLocalPath>
     <!-- <BlockchainToolkitLibraryVersion>local</BlockchainToolkitLibraryVersion> -->
   </PropertyGroup>

--- a/src/assertions/NeoAssertionsExtensions.cs
+++ b/src/assertions/NeoAssertionsExtensions.cs
@@ -1,4 +1,3 @@
-using Neo.Ledger;
 using Neo.SmartContract;
 using Neo.VM.Types;
 

--- a/src/assertions/NotifyEventArgsAssertions.cs
+++ b/src/assertions/NotifyEventArgsAssertions.cs
@@ -4,10 +4,7 @@ using System.Linq.Expressions;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
-using Neo;
-using Neo.Persistence;
 using Neo.SmartContract;
-using Neo.SmartContract.Manifest;
 
 namespace Neo.Assertions
 {

--- a/src/assertions/StackItemAssertions.cs
+++ b/src/assertions/StackItemAssertions.cs
@@ -3,9 +3,7 @@ using System.Numerics;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
-using Neo;
 using Neo.VM.Types;
-
 
 namespace Neo.Assertions
 {

--- a/src/assertions/assertions.csproj
+++ b/src/assertions/assertions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Neo" Version="$(NeoVersion)" />
   </ItemGroup>
 

--- a/src/build-tasks/NeoCsc.cs
+++ b/src/build-tasks/NeoCsc.cs
@@ -31,7 +31,7 @@ namespace Neo.BuildTasks
         public ITaskItem[] OutputFiles => outputFiles;
 
         protected override string GetArguments()
-        { 
+        {
             var builder = new StringBuilder();
             foreach (var file in Files)
             {

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -44,11 +44,6 @@ namespace Neo.BuildTasks
 
             completeEvent.WaitOne();
 
-            // while (!process.HasExited)
-            // {
-            //     Thread.Sleep(50);
-            // }
-
             return new Results(process.ExitCode, output, error);
         }
     }

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -36,7 +36,7 @@ namespace Neo.BuildTasks
 
             ManualResetEvent completeEvent = new(false);
 
-            process.Exited += (_, _) => completeEvent.Set(); 
+            process.Exited += (_, _) => completeEvent.Set();
 
             if (!process.Start()) throw new Exception("Process failed to start");
             process.BeginOutputReadLine();

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -76,9 +76,8 @@
     Inputs="@(NeoCscOutput);$(NeoExpressBatchFile);$(NeoExpressTouchFile)" Outputs="$(NeoExpressTouchFile)">
 
     <PropertyGroup>
-      <NeoExpressNormalizedBatchFile>$([MSBuild]::NormalizePath($(MSBuildProjectDirectory), $(NeoExpressBatchFile)))</NeoExpressNormalizedBatchFile>
       <NeoExpressBatchReset>true</NeoExpressBatchReset>
-      <NeoExpressBatchReset Condition="'(NeoExpressBatchNoReset)'=='true'">false</NeoExpressBatchReset>
+      <NeoExpressBatchReset Condition="'$(NeoExpressBatchNoReset)'=='true'">false</NeoExpressBatchReset>
     </PropertyGroup>
 
     <NeoExpressBatch 

--- a/src/runner/Extensions.cs
+++ b/src/runner/Extensions.cs
@@ -4,7 +4,6 @@ using System.IO.Abstractions;
 using System.Linq;
 using Neo.BlockchainToolkit;
 using Neo.BlockchainToolkit.Models;
-using Neo.BlockchainToolkit.SmartContract;
 using Neo.Persistence;
 using Neo.SmartContract.Native;
 

--- a/src/runner/runner.csproj
+++ b/src/runner/runner.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Nito.Disposables" Version="2.2.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="Nito.Disposables" Version="2.3.0" />
   </ItemGroup>
 
   <Choose>

--- a/src/test-harness/Extensions.cs
+++ b/src/test-harness/Extensions.cs
@@ -98,14 +98,14 @@ namespace NeoTestHarness
         }
 
         public static NeoStorage StorageMap(this NeoStorage storages, string prefix)
-            => storages.StorageMap(Utility.StrictUTF8.GetBytes(prefix));
+            => storages.StorageMap(Neo.Utility.StrictUTF8.GetBytes(prefix));
 
         public static NeoStorage StorageMap(this NeoStorage storages, ReadOnlyMemory<byte> prefix)
             => storages.Where(kvp => kvp.Key.Span.StartsWith(prefix.Span))
                 .ToImmutableDictionary(kvp => kvp.Key.Slice(prefix.Length), kvp => kvp.Value, MemoryEqualityComparer.Instance);
 
         public static bool TryGetValue(this NeoStorage storage, string key, [NotNullWhen(true)] out StorageItem item)
-            => storage.TryGetValue(Utility.StrictUTF8.GetBytes(key), out item!);
+            => storage.TryGetValue(Neo.Utility.StrictUTF8.GetBytes(key), out item!);
 
         public static bool TryGetValue(this NeoStorage storage, UInt160 key, [NotNullWhen(true)] out StorageItem item)
             => storage.TryGetValue(Neo.IO.Helper.ToArray(key), out item!);

--- a/src/test-harness/NativeContractInterfaces/NeoToken.cs
+++ b/src/test-harness/NativeContractInterfaces/NeoToken.cs
@@ -1,0 +1,18 @@
+namespace NeoTestHarness.NativeContractInterfaces
+{
+    public interface NeoToken : Nep17Token
+    {
+        Neo.VM.Types.Array getAccountState(Neo.UInt160 account);
+        Neo.VM.Types.Array getCandidates();
+        Neo.VM.Types.Array getCommittee();
+        System.Numerics.BigInteger getGasPerBlock();
+        Neo.VM.Types.Array getNextBlockValidators();
+        System.Numerics.BigInteger getRegisterPrice();
+        bool registerCandidate(Neo.Cryptography.ECC.ECPoint pubkey);
+        void setGasPerBlock(System.Numerics.BigInteger gasPerBlock);
+        void setRegisterPrice(System.Numerics.BigInteger registerPrice);
+        System.Numerics.BigInteger unclaimedGas(Neo.UInt160 account, System.Numerics.BigInteger end);
+        bool unregisterCandidate(Neo.Cryptography.ECC.ECPoint pubkey);
+        bool vote(Neo.UInt160 account, Neo.Cryptography.ECC.ECPoint voteTo);
+    }
+}

--- a/src/test-harness/NativeContractInterfaces/Nep17Token.cs
+++ b/src/test-harness/NativeContractInterfaces/Nep17Token.cs
@@ -1,0 +1,16 @@
+namespace NeoTestHarness.NativeContractInterfaces
+{
+    public interface Nep17Token
+    {
+        System.Numerics.BigInteger balanceOf(Neo.UInt160 account);
+        System.Numerics.BigInteger decimals();
+        string symbol();
+        System.Numerics.BigInteger totalSupply();
+        bool transfer(Neo.UInt160 @from, Neo.UInt160 to, System.Numerics.BigInteger amount, object data);
+
+        interface Events
+        {
+            void Transfer(Neo.UInt160 @from, Neo.UInt160 to, System.Numerics.BigInteger amount);
+        }
+    }
+}

--- a/src/test-harness/NativeContracts.cs
+++ b/src/test-harness/NativeContracts.cs
@@ -1,0 +1,14 @@
+using System;
+using Neo;
+
+namespace NeoTestHarness
+{
+    public static class NativeContracts
+    {
+        static Lazy<UInt160> neoToken = new Lazy<UInt160>(() => UInt160.Parse("0xef4073a0f2b305a38ec4050e4d3d28bc40ea63f5"));
+        public static UInt160 NeoToken => neoToken.Value;
+
+        static Lazy<UInt160> gasToken = new Lazy<UInt160>(() => UInt160.Parse("0xd2a4cff31913016155e38e474a2c06d08be276cf"));
+        public static UInt160 GasToken => gasToken.Value;
+    }
+}

--- a/src/test-harness/test-harness.csproj
+++ b/src/test-harness/test-harness.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>neo-test-harness</AssemblyName>
     <PackageId>Neo.Test.Harness</PackageId>
-    <RootNamespace>Neo.Test.Harness</RootNamespace>
+    <RootNamespace>NeoTestHarness</RootNamespace>
   </PropertyGroup>
 
   <Choose>

--- a/test/test-build-tasks/test-build-tasks.csproj
+++ b/test/test-build-tasks/test-build-tasks.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Other changes:
* Add EmitContractCall ext methods to NeoTestHarness
* Add contract interface declarations for Nep17Token and NeoToken to NeoTestHarness
* Add contract hash properties for NeoToken and GasToken to NeoTestHarness
* fix NeoExpressBatchReset msbuild property in Neo.BuildTasks 
