### PR TITLE
ValidateVersion

### DIFF
--- a/src/build-tasks/NeoCsc.cs
+++ b/src/build-tasks/NeoCsc.cs
@@ -9,6 +9,7 @@ namespace Neo.BuildTasks
 {
     public class NeoCsc : DotNetToolTask
     {
+        readonly static NugetPackageVersion REQUIRED_VERSION = new NugetPackageVersion(3, 3, 0);
         const string PACKAGE_ID = "Neo.Compiler.CSharp";
         const string COMMAND = "nccs";
         const byte DEFAULT_ADDRESS_VERSION = 53;
@@ -29,6 +30,16 @@ namespace Neo.BuildTasks
 
         [Output]
         public ITaskItem[] OutputFiles => outputFiles;
+
+        protected override bool ValidateVersion(NugetPackageVersion version)
+        {
+            if (version < REQUIRED_VERSION)
+            {
+                Log.LogWarning($"{nameof(NeoCsc)} requires {REQUIRED_VERSION}. {version} found");
+                return false;
+            }
+            return true;
+        }
 
         protected override string GetArguments()
         {

--- a/src/build-tasks/NugetPackageVersion.cs
+++ b/src/build-tasks/NugetPackageVersion.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+
+namespace Neo.BuildTasks
+{
+    // https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-basics
+    public readonly struct NugetPackageVersion : IComparable<NugetPackageVersion>
+    {
+        public readonly int Major;
+        public readonly int Minor;
+        public readonly int Patch;
+        public readonly string Suffix;
+
+        public NugetPackageVersion(int major, int minor, int patch, string suffix = "")
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+            Suffix = suffix;
+        }
+
+        public override string ToString()
+        {
+            var core = $"{Major}.{Minor}.{Patch}";
+            return Suffix.Length == 0 ? core : core + $"-{Suffix}";
+        }
+
+        public static bool TryParse(string input, out NugetPackageVersion version)
+        {
+            version = default;
+
+            int majorStart = 0;
+            int majorEnd = input.IndexOf('.');
+            if (majorEnd < 0) return false;
+            var majorText = input.Substring(0, majorEnd - majorStart);
+            if (!int.TryParse(majorText, System.Globalization.NumberStyles.Integer, null, out var major))
+                return false;
+
+            var minorStart = majorEnd + 1;
+            var minorEnd = input.IndexOf('.', minorStart);
+            if (minorEnd < 0) return false;
+            var minorText = input.Substring(minorStart, minorEnd - minorStart);
+            if (!int.TryParse(minorText, System.Globalization.NumberStyles.Integer, null, out var minor))
+                return false;
+
+            var patchStart = minorEnd + 1;
+            var patchEnd = input.IndexOf('-', patchStart);
+            if (patchEnd < 0)
+            {
+                var patchText = input.Substring(patchStart);
+                if (!int.TryParse(patchText, System.Globalization.NumberStyles.Integer, null, out var patch))
+                    return false;
+
+                version = new NugetPackageVersion(major, minor, patch);
+                return true;
+            }
+            else
+            {
+                var patchText = input.Substring(patchStart, patchEnd - patchStart);
+                if (!int.TryParse(patchText, System.Globalization.NumberStyles.Integer, null, out var patch))
+                    return false;
+                var suffix = input.Substring(patchEnd + 1);
+                version = new NugetPackageVersion(major, minor, patch, suffix);
+                return true;
+            }
+        }
+
+        public int CompareTo(NugetPackageVersion other)
+        {
+            var result = Major.CompareTo(other.Major);
+            if (result != 0) return result;
+
+            result = Minor.CompareTo(other.Minor);
+            if (result != 0) return result;
+
+            result = Patch.CompareTo(other.Patch);
+            if (result != 0) return result;
+
+            if (Suffix.Length == 0 && other.Suffix.Length > 0) return 1;
+            if (Suffix.Length > 0 && other.Suffix.Length == 0) return -1;
+            return string.Compare(Suffix, other.Suffix, true);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is NugetPackageVersion version &&
+                   Major == version.Major &&
+                   Minor == version.Minor &&
+                   Patch == version.Patch &&
+                   Suffix == version.Suffix;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -261206211;
+            hashCode = hashCode * -1521134295 + Major.GetHashCode();
+            hashCode = hashCode * -1521134295 + Minor.GetHashCode();
+            hashCode = hashCode * -1521134295 + Patch.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Suffix);
+            return hashCode;
+        }
+
+        public static bool operator ==(in NugetPackageVersion left, in NugetPackageVersion right)
+        {
+            return left.CompareTo(right) == 0;
+        }
+
+        public static bool operator !=(in NugetPackageVersion left, in NugetPackageVersion right)
+        {
+            return left.CompareTo(right) != 0;
+        }
+
+        public static bool operator >(in NugetPackageVersion left, in NugetPackageVersion right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
+        public static bool operator >=(in NugetPackageVersion left, in NugetPackageVersion right)
+        {
+            return left.CompareTo(right) >= 0;
+        }
+
+        public static bool operator <(in NugetPackageVersion left, in NugetPackageVersion right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        public static bool operator <=(in NugetPackageVersion left, in NugetPackageVersion right)
+        {
+            return left.CompareTo(right) <= 0;
+        }
+    }
+}

--- a/src/build-tasks/ProcessRunner.cs
+++ b/src/build-tasks/ProcessRunner.cs
@@ -2,16 +2,19 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Neo.BuildTasks
 {
-    // https://github.com/jamesmanning/RunProcessAsTask
-    class ProcessRunner
+    public interface IProcessRunner
     {
-        public record struct Results(int ExitCode, IReadOnlyCollection<string> Output, IReadOnlyCollection<string> Error);
+        record struct Results(int ExitCode, IReadOnlyCollection<string> Output, IReadOnlyCollection<string> Error);
+        Results Run(string command, string arguments, string? workingDirectory = null);
+    }
 
-        public static Results Run(string command, string arguments, string? workingDirectory = null)
+    // https://github.com/jamesmanning/RunProcessAsTask
+    class ProcessRunner : IProcessRunner
+    {
+        public IProcessRunner.Results Run(string command, string arguments, string? workingDirectory = null)
         {
             var startInfo = new System.Diagnostics.ProcessStartInfo(command, arguments)
             {
@@ -44,7 +47,7 @@ namespace Neo.BuildTasks
 
             completeEvent.WaitOne();
 
-            return new Results(process.ExitCode, output, error);
+            return new IProcessRunner.Results(process.ExitCode, output, error);
         }
     }
 }

--- a/src/build-tasks/build-tasks.csproj
+++ b/src/build-tasks/build-tasks.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="test-build-tasks" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="build\*" PackagePath="build\" />
     <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting\" />
   </ItemGroup>

--- a/test/test-build-tasks/TestDotNetToolTask.cs
+++ b/test/test-build-tasks/TestDotNetToolTask.cs
@@ -1,0 +1,135 @@
+using System;
+using Moq;
+using Neo.BuildTasks;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestDotNetToolTask
+    {
+        class TestTask : DotNetToolTask
+        {
+            protected override string Command => "nccs";
+            protected override string PackageId => "Neo.Compiler.CSharp";
+
+            readonly Func<NugetPackageVersion, bool> validator;
+
+            public TestTask(IProcessRunner processRunner, Func<NugetPackageVersion, bool> validator = null) : base(processRunner)
+            {
+                this.validator = validator;
+            }
+
+            protected override string GetArguments() => string.Empty;
+
+            protected override bool ValidateVersion(NugetPackageVersion version)
+                => validator is null ? true : validator(version);
+        }
+
+        [Fact]
+        public void contains_package()
+        {
+            var output = localOutput.Split(Environment.NewLine);
+            Assert.True(DotNetToolTask.ContainsPackage(output, "Neo.Compiler.CSharp", out var version));
+            Assert.Equal(new NugetPackageVersion(3, 3, 0), version);
+        }
+
+        [Fact]
+        public void cant_find_valid_version()
+        {
+            Func<NugetPackageVersion, bool> validate = ver => false;
+
+            var processRunner = GetProcRunner();
+            var taskItem = new Mock<Microsoft.Build.Framework.ITaskItem>();
+            taskItem.Setup(item => item.ItemSpec).Returns("fakePath");
+
+            var task = new TestTask(processRunner.Object, validate);
+            Assert.False(task.FindTool("neo.compiler.csharp", taskItem.Object, out var type, out var version));
+        }
+
+        [Fact]
+        public void find_valid_global_version()
+        {
+            var expectedVersion = new NugetPackageVersion(3, 1, 0);
+            Func<NugetPackageVersion, bool> validate = ver => ver == expectedVersion;
+
+            var processRunner = GetProcRunner();
+            var taskItem = new Mock<Microsoft.Build.Framework.ITaskItem>();
+            taskItem.Setup(item => item.ItemSpec).Returns("fakePath");
+
+            var task = new TestTask(processRunner.Object, validate);
+            Assert.True(task.FindTool("neo.compiler.csharp", taskItem.Object, out var type, out var version));
+            Assert.Equal(DotNetToolType.Global, type);
+            Assert.Equal(expectedVersion, version);
+        }
+
+
+        [Fact]
+        public void find_valid_local_version()
+        {
+            var expectedVersion = new NugetPackageVersion(3, 3, 0);
+            Func<NugetPackageVersion, bool> validate = ver => true;
+
+            var processRunner = GetProcRunner();
+            var taskItem = new Mock<Microsoft.Build.Framework.ITaskItem>();
+            taskItem.Setup(item => item.ItemSpec).Returns("fakePath");
+
+            var task = new TestTask(processRunner.Object, validate);
+            Assert.True(task.FindTool("neo.compiler.csharp", taskItem.Object, out var type, out var version));
+            Assert.Equal(DotNetToolType.Local, type);
+            Assert.Equal(expectedVersion, version);
+        }
+
+        
+        [Fact]
+        public void find_valid_prerel_version()
+        {
+            var expectedVersion = new NugetPackageVersion(3, 3, 1037, "storage-schema-preview");
+            Func<NugetPackageVersion, bool> validate = ver => ver >= new NugetPackageVersion(3,3,0);
+
+            var processRunner = GetProcRunner(sspOutput);
+            var taskItem = new Mock<Microsoft.Build.Framework.ITaskItem>();
+            taskItem.Setup(item => item.ItemSpec).Returns("fakePath");
+
+            var task = new TestTask(processRunner.Object, validate);
+            Assert.True(task.FindTool("neo.compiler.csharp", taskItem.Object, out var type, out var version));
+            Assert.Equal(DotNetToolType.Local, type);
+            Assert.Equal(expectedVersion, version);
+        }
+
+        static Mock<IProcessRunner> GetProcRunner(string local = localOutput, string global = globalOutput)
+        {
+            var processRunner = new Mock<IProcessRunner>();
+            processRunner
+                .Setup(r => r.Run("dotnet", "tool list --local", It.IsAny<string>()))
+                .Returns(new IProcessRunner.Results(0, local.Split(Environment.NewLine), Array.Empty<string>()));
+            processRunner
+                .Setup(r => r.Run("dotnet", "tool list --global", It.IsAny<string>()))
+                .Returns(new IProcessRunner.Results(0, global.Split(Environment.NewLine), Array.Empty<string>()));
+            return processRunner;
+        }
+
+        const string sspOutput = @"Package Id               Version                              Commands      Manifest
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+neo.express              3.1.46                               neoxp         C:\Users\harry\Source\neo\seattle\samples\nft-sample\.config\dotnet-tools.json
+neo.compiler.csharp      3.3.1037-storage-schema-preview      nccs          C:\Users\harry\Source\neo\seattle\samples\nft-sample\.config\dotnet-tools.json";
+
+        const string localOutput = @"Package Id               Version            Commands             Manifest
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+neo.express              3.3.7-preview      neoxp                C:\Users\harry\Source\neo\seattle\samples\registrar-sample\.config\dotnet-tools.json
+neo.compiler.csharp      3.3.0              nccs                 C:\Users\harry\Source\neo\seattle\samples\registrar-sample\.config\dotnet-tools.json
+neo.trace                3.3.7-preview      neotrace             C:\Users\harry\Source\neo\seattle\samples\registrar-sample\.config\dotnet-tools.json
+neo.test.runner          3.3.4-preview      neo-test-runner      C:\Users\harry\Source\neo\seattle\samples\registrar-sample\.config\dotnet-tools.json";
+
+        const string globalOutput = @"Package Id                Version            Commands       
+------------------------------------------------------------
+devhawk.dumpnef           3.2.8-preview      dumpnef
+dotnet-outdated-tool      4.1.0              dotnet-outdated
+dotnet-script             1.3.1              dotnet-script
+dotnet-t4                 2.2.1              t4
+fornax                    0.14.0             fornax
+nbgv                      3.4.255            nbgv
+neo.compiler.csharp       3.1.0              nccs
+neo.express               3.1.49             neoxp
+sleet                     5.0.1              sleet";
+    }
+}

--- a/test/test-build-tasks/TestNugetPackageVersion.cs
+++ b/test/test-build-tasks/TestNugetPackageVersion.cs
@@ -1,0 +1,108 @@
+using Neo.BuildTasks;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestNugetPackageVersion
+    {
+        [Fact]
+        public void parse_simple_version()
+        {
+            Assert.True(NugetPackageVersion.TryParse("1.2.3", out var version));
+            Assert.Equal(1, version.Major);
+            Assert.Equal(2, version.Minor);
+            Assert.Equal(3, version.Patch);
+            Assert.Equal(string.Empty, version.Suffix);
+        }
+
+        [Fact]
+        public void parse_dotnet_version_fails()
+        {
+            Assert.False(NugetPackageVersion.TryParse("1.2.3.4", out var version));
+        }
+
+        [Fact]
+        public void parse_version_with_prerel()
+        {
+            Assert.True(NugetPackageVersion.TryParse("1.2.3-prerel", out var version));
+            Assert.Equal(1, version.Major);
+            Assert.Equal(2, version.Minor);
+            Assert.Equal(3, version.Patch);
+            Assert.Equal("prerel", version.Suffix);
+        }
+
+        [Fact]
+        public void parse_version_with_build_id_fails()
+        {
+            Assert.False(NugetPackageVersion.TryParse("1.2.3+21AF26D3", out var version));
+        }
+
+        [Fact]
+        public void parse_version_with_prerel_and_build_id()
+        {
+            Assert.True(NugetPackageVersion.TryParse("1.2.3-alpha+001", out var version));
+            Assert.Equal(1, version.Major);
+            Assert.Equal(2, version.Minor);
+            Assert.Equal(3, version.Patch);
+            Assert.Equal("alpha+001", version.Suffix);
+        }
+
+        [Fact]
+        public void compare_major()
+        {
+            var one = new NugetPackageVersion(1, 0, 0);
+            var two = new NugetPackageVersion(2, 0, 0);
+            var result = one.CompareTo(two);
+            Assert.True(result < 0);
+        }
+
+        [Fact]
+        public void compare_minor()
+        {
+            var one = new NugetPackageVersion(1, 2, 0);
+            var two = new NugetPackageVersion(1, 3, 0);
+            var result = one.CompareTo(two);
+            Assert.True(result < 0);
+        }
+
+        [Fact]
+        public void compare_patch()
+        {
+            var one = new NugetPackageVersion(1, 2, 3);
+            var two = new NugetPackageVersion(1, 2, 4);
+            var result = one.CompareTo(two);
+            Assert.True(result < 0);
+        }
+
+        [Fact]
+        public void compare_no_suffix()
+        {
+            var one = new NugetPackageVersion(1, 2, 3);
+            var two = new NugetPackageVersion(1, 2, 3);
+            var result = one.CompareTo(two);
+            Assert.True(result == 0);
+        }
+
+        [Fact]
+        public void compare_suffix_to_no_suffix()
+        {
+            var one = new NugetPackageVersion(1, 2, 3, "prerel");
+            var two = new NugetPackageVersion(1, 2, 3);
+            var result = one.CompareTo(two);
+            Assert.True(result < 0);
+        }
+
+        [Fact]
+        public void compare_both_have_suffix()
+        {
+            var one = new NugetPackageVersion(1, 2, 3, "alpha");
+            var two = new NugetPackageVersion(1, 2, 3, "beta");
+            var result = one.CompareTo(two);
+            Assert.True(result < 0);
+        }
+
+
+
+
+    }
+}

--- a/test/test-build-tasks/test-build-tasks.csproj
+++ b/test/test-build-tasks/test-build-tasks.csproj
@@ -11,7 +11,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="moq" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR adds virtual `ValidateVersion` method to DotNetToolTask to let subclasses control what version of a tool is supported. Used to ensure `nccs` is at least version 3.3.0 or later.

Other changes
* added NugetPackageVersion struct
* Added `IProcessRunner` for test enablement