### PR TITLE
Update NeoContractInterface + targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ may not exactly match a publicly released version.
 
 ## [Unreleased]
 
+### Added 
+
+* `InterfaceName` property for `NeoContractInterface` Task
+* `ContractNameOverride` MSBuild item property to enable specifying name of generated contract interface
+
+### Changed
+
+* Modified Neo.BuildTasks.targets to enable specifying path to .manifest.json file via `<NeoContractInfo>` MSBuild items.
+* `NeoContractInterface` fails if generated contract interface name isn't a valid C# type name
+
+## [3.3] - 2022-06-28
+
 ### Added
 
 * NeoCsc and NeoExpressBatch MSBuild tasks (plus .targets file)
@@ -24,7 +36,6 @@ may not exactly match a publicly released version.
 * `NativeContracts` static class 
   * `NeoToken` and `GasToken` contract hashes
 * `Nep17Token` and `NeoToken` contract interfaces for use with `NeoTestHarness`
-
 
 ### Changed
 

--- a/src/build-tasks/CSharpHelpers.cs
+++ b/src/build-tasks/CSharpHelpers.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Adapted from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/CSharpHelpers.cs
+
+using System.Collections.Immutable;
+using System.Globalization;
+
+namespace Neo.BuildTasks
+{
+    static class CSharpHelpers
+    {
+        // generated from Roslyn C# 4.2 SyntaxFacts.GetKeywordKinds().Select(k => SyntaxFacts.GetText(k)).OrderBy(k => k)
+        static readonly ImmutableHashSet<string> CSHARP_KEYWORDS = ImmutableHashSet.Create("__arglist", "__makeref",
+            "__reftype", "__refvalue", "abstract", "add", "alias", "and", "as", "ascending", "assembly", "async",
+            "await", "base", "bool", "break", "by", "byte", "case", "catch", "char", "checked", "class", "const",
+            "continue", "decimal", "default", "delegate", "descending", "do", "double", "else", "enum", "equals",
+            "event", "explicit", "extern", "false", "field", "finally", "fixed", "float", "for", "foreach", "from",
+            "get", "global", "goto", "group", "if", "implicit", "in", "init", "int", "interface", "internal", "into",
+            "is", "join", "let", "lock", "long", "managed", "method", "module", "nameof", "namespace", "new", "not",
+            "null", "object", "on", "operator", "or", "orderby", "out", "override", "param", "params", "partial",
+            "private", "property", "protected", "public", "readonly", "record", "ref", "remove", "return", "sbyte",
+            "sealed", "select", "set", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this",
+            "throw", "true", "try", "type", "typeof", "typevar", "uint", "ulong", "unchecked", "unmanaged", "unsafe",
+            "ushort", "using", "virtual", "void", "volatile", "when", "where", "while", "with", "yield");
+
+        public static string CreateEscapedIdentifier(string name)
+        {
+            // Any identifier started with two consecutive underscores are
+            // reserved by CSharp.
+            if (IsKeyword(name) || IsPrefixTwoUnderscore(name))
+            {
+                return "@" + name;
+            }
+            return name;
+
+            static bool IsKeyword(string value)
+            {
+                return CSHARP_KEYWORDS.Contains(value);
+            }
+
+            static bool IsPrefixTwoUnderscore(string value)
+            {
+                if (value.Length < 3)
+                {
+                    return false;
+                }
+                else
+                {
+                    return ((value[0] == '_') && (value[1] == '_') && (value[2] != '_'));
+                }
+            }
+        }
+
+        public static bool IsValidTypeName(string value) => IsValidTypeNameOrIdentifier(value, true);
+        public static bool IsValidIdentifier(string value) => IsValidTypeNameOrIdentifier(value, false);
+
+        static bool IsValidTypeNameOrIdentifier(string value, bool isTypeName)
+        {
+            bool nextMustBeStartChar = true;
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            // each char must be Lu, Ll, Lt, Lm, Lo, Nd, Mn, Mc, Pc
+            //
+            for (int i = 0; i < value.Length; i++)
+            {
+                char ch = value[i];
+                UnicodeCategory uc = CharUnicodeInfo.GetUnicodeCategory(ch);
+                switch (uc)
+                {
+                    case UnicodeCategory.UppercaseLetter:        // Lu
+                    case UnicodeCategory.LowercaseLetter:        // Ll
+                    case UnicodeCategory.TitlecaseLetter:        // Lt
+                    case UnicodeCategory.ModifierLetter:         // Lm
+                    case UnicodeCategory.LetterNumber:           // Lm
+                    case UnicodeCategory.OtherLetter:            // Lo
+                        nextMustBeStartChar = false;
+                        break;
+
+                    case UnicodeCategory.NonSpacingMark:         // Mn
+                    case UnicodeCategory.SpacingCombiningMark:   // Mc
+                    case UnicodeCategory.ConnectorPunctuation:   // Pc
+                    case UnicodeCategory.DecimalDigitNumber:     // Nd
+                        // Underscore is a valid starting character, even though it is a ConnectorPunctuation.
+                        if (nextMustBeStartChar && ch != '_')
+                            return false;
+
+                        nextMustBeStartChar = false;
+                        break;
+                    default:
+                        // We only check the special Type chars for type names.
+                        if (isTypeName && IsSpecialTypeChar(ch, ref nextMustBeStartChar))
+                        {
+                            break;
+                        }
+
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        // This can be a special character like a separator that shows up in a type name
+        // This is an odd set of characters.  Some come from characters that are allowed by C++, like < and >.
+        // Others are characters that are specified in the type and assembly name grammar.
+        static bool IsSpecialTypeChar(char ch, ref bool nextMustBeStartChar)
+        {
+            switch (ch)
+            {
+                case ':':
+                case '.':
+                case '$':
+                case '+':
+                case '<':
+                case '>':
+                case '-':
+                case '[':
+                case ']':
+                case ',':
+                case '&':
+                case '*':
+                    nextMustBeStartChar = true;
+                    return true;
+
+                case '`':
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/build-tasks/ContractGenerator.cs
+++ b/src/build-tasks/ContractGenerator.cs
@@ -1,29 +1,22 @@
 using System;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
+using static Neo.BuildTasks.CSharpHelpers;
 
 namespace Neo.BuildTasks
 {
     public static class ContractGenerator
     {
-        // generated from Roslyn C# 4.1 SyntaxFacts.GetKeywordKinds().Select(k => SyntaxFacts.GetText(k)).OrderBy(k => k)
-        static readonly ImmutableHashSet<string> CSHARP_KEYWORDS = ImmutableHashSet.Create("__arglist", "__makeref",
-            "__reftype", "__refvalue", "abstract", "add", "alias", "and", "as", "ascending", "assembly", "async",
-            "await", "base", "bool", "break", "by", "byte", "case", "catch", "char", "checked", "class", "const",
-            "continue", "decimal", "default", "delegate", "descending", "do", "double", "else", "enum", "equals",
-            "event", "explicit", "extern", "false", "field", "finally", "fixed", "float", "for", "foreach", "from",
-            "get", "global", "goto", "group", "if", "implicit", "in", "init", "int", "interface", "internal", "into",
-            "is", "join", "let", "lock", "long", "managed", "method", "module", "nameof", "namespace", "new", "not",
-            "null", "object", "on", "operator", "or", "orderby", "out", "override", "param", "params", "partial",
-            "private", "property", "protected", "public", "readonly", "record", "ref", "remove", "return", "sbyte",
-            "sealed", "select", "set", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", "this",
-            "throw", "true", "try", "type", "typeof", "typevar", "uint", "ulong", "unchecked", "unmanaged", "unsafe",
-            "ushort", "using", "virtual", "void", "volatile", "when", "where", "while", "with", "yield");
-
-        public static string GenerateContractInterface(NeoManifest manifest, string @namespace = "")
+        public static string GenerateContractInterface(NeoManifest manifest, string @namespace, string interfaceName)
         {
-            var contractName = Regex.Replace(manifest.Name, "^.*\\.", string.Empty);
+            var contractName = string.IsNullOrEmpty(interfaceName)
+                ? Regex.Replace(manifest.Name, "^.*\\.", string.Empty)
+                : interfaceName;
+
+            if (!IsValidTypeName(contractName)) 
+            {
+                throw new InvalidOperationException($"{contractName} is not a valid C# type name");
+            }
 
             var builder = new IndentedStringBuilder();
 
@@ -57,7 +50,7 @@ namespace Neo.BuildTasks
                 if (method.Name.StartsWith("_")) continue;
 
                 builder.Append($"{ConvertParameterType(method.ReturnType)} {method.Name}(");
-                builder.Append(string.Join(", ", method.Parameters.Select(p => $"{ConvertParameterType(p.Type)} {ConvertIdentifier(p.Name)}")));
+                builder.Append(string.Join(", ", method.Parameters.Select(p => $"{ConvertParameterType(p.Type)} {CreateEscapedIdentifier(p.Name)}")));
                 builder.AppendLine(");");
             }
 
@@ -69,7 +62,7 @@ namespace Neo.BuildTasks
                 {
                     var @event = manifest.Events[i];
                     builder.Append($"void {@event.Name}(");
-                    builder.Append(string.Join(", ", @event.Parameters.Select(p => $"{ConvertParameterType(p.Type)} {ConvertIdentifier(p.Name)}")));
+                    builder.Append(string.Join(", ", @event.Parameters.Select(p => $"{ConvertParameterType(p.Type)} {CreateEscapedIdentifier(p.Name)}")));
                     builder.AppendLine($");");
                 }
                 builder.DecrementIndent();
@@ -86,8 +79,6 @@ namespace Neo.BuildTasks
             }
 
             return builder.ToString();
-
-            static string ConvertIdentifier(string text) => CSHARP_KEYWORDS.Contains(text) ? $"@{text}" : text;
 
             static string ConvertParameterType(string parameterType) => parameterType switch
             {

--- a/src/build-tasks/NeoContractInterface.cs
+++ b/src/build-tasks/NeoContractInterface.cs
@@ -15,12 +15,17 @@ namespace Neo.BuildTasks
             }
             else
             {
-                var manifest = NeoManifest.Load(ManifestFile);
-                var source = ContractGenerator.GenerateContractInterface(manifest, RootNamespace);
-                if (!string.IsNullOrEmpty(source))
+                try
                 {
+                    var manifest = NeoManifest.Load(ManifestFile);
+                    var source = ContractGenerator.GenerateContractInterface(manifest, RootNamespace, InterfaceName);
+                    if (string.IsNullOrEmpty(source)) throw new InvalidOperationException("Contract interface generation failed");
                     Directory.CreateDirectory(Path.GetDirectoryName(this.OutputFile));
                     FileOperationWithRetry(() => File.WriteAllText(this.OutputFile, source));
+                }
+                catch (Exception ex)
+                {
+                    Log.LogError(ex.Message);
                 }
             }
             return !Log.HasLoggedErrors;
@@ -33,6 +38,8 @@ namespace Neo.BuildTasks
         public string ManifestFile { get; set; } = "";
 
         public string RootNamespace { get; set; } = "";
+
+        public string InterfaceName { get; set; } = "";
 
         static void FileOperationWithRetry(Action operation)
         {

--- a/src/build-tasks/NeoManifest.cs
+++ b/src/build-tasks/NeoManifest.cs
@@ -28,8 +28,8 @@ namespace Neo.BuildTasks
 
         public static NeoManifest Load(string manifestPath)
         {
-            var text = File.ReadAllText(manifestPath) ?? throw new FileNotFoundException("", manifestPath);
-            var json = SimpleJSON.JSON.Parse(text) ?? throw new InvalidOperationException();
+            if (!File.Exists(manifestPath)) throw new FileNotFoundException("Manifest not found", manifestPath);
+            var json = SimpleJSON.JSON.Parse(File.ReadAllText(manifestPath)) ?? throw new InvalidOperationException("Manifest JSON parsing failed");
             return NeoManifest.FromManifestJson(json);
         }
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -95,7 +95,8 @@
     <Message Importance="High" Text="NeoExpress Batch -> $(NeoExpressNormalizedBatchFile)" />
   </Target>
 
-  <Target Name="ConfigureNeoContractInterface" BeforeTargets="$(BuildDependsOn);Build" Condition="'@(NeoContractReference)'!=''">
+  <Target Name="ProcessNeoContractReferences" BeforeTargets="$(BuildDependsOn);Build" Condition="'@(NeoContractReference)'!=''">
+
     <ItemGroup>
       <ProjectReference Include="@(NeoContractReference)" ReferenceOutputAssembly="false" />
     </ItemGroup>
@@ -106,10 +107,16 @@
 
     <Message Importance="High" Text="NeoContractInfo @(NeoContractInfo) -> %(ManifestPath)" />
 
+  </Target>
+
+  <Target Name="ConfigureNeoContractInterface" Condition="'@(NeoContractInfo)'!=''"
+          DependsOnTargets="ProcessNeoContractReferences" BeforeTargets="$(BuildDependsOn);Build" >
+
     <ItemGroup>
       <NeoContractGeneration Include="%(NeoContractInfo.Identity)">
         <ManifestPath>%(NeoContractInfo.ManifestPath)</ManifestPath>
         <OutputPath>$(IntermediateOutputPath)%(Identity).contract-interface.cs</OutputPath>
+        <ContractNameOverride>%(NeoContractInfo.ContractNameOverride)</ContractNameOverride>
       </NeoContractGeneration>
     </ItemGroup>
 
@@ -117,15 +124,15 @@
 
   </Target>
 
-  <Target Name="GenerateNeoContractInterface" AfterTargets="ResolveProjectReferences" 
-    DependsOnTargets="ConfigureNeoContractInterface"
-    Condition="'@(NeoContractReference)'!=''"
-    Inputs="%(NeoContractGeneration.ManifestPath)" Outputs="%(NeoContractGeneration.OutputPath)">
+  <Target Name="GenerateNeoContractInterface" 
+          DependsOnTargets="ConfigureNeoContractInterface" AfterTargets="ResolveProjectReferences" 
+          Inputs="%(NeoContractGeneration.ManifestPath)" Outputs="%(NeoContractGeneration.OutputPath)">
 
     <NeoContractInterface
       ManifestFile="%(NeoContractGeneration.ManifestPath)"
       OutputFile="%(NeoContractGeneration.OutputPath)"
-      RootNamespace="$(RootNamespace)"/>
+      RootNamespace="$(RootNamespace)"
+      InterfaceName="%(NeoContractGeneration.ContractNameOverride)"/>
 
     <ItemGroup>
       <Compile Include="%(NeoContractGeneration.OutputPath)" />

--- a/test/native-contracts/Program.cs
+++ b/test/native-contracts/Program.cs
@@ -39,7 +39,7 @@ namespace native_contracts
             foreach (var result in results)
             {
                 var manifest = NeoManifest.FromManifestJson((JSONObject)result.Value["manifest"]);
-                var source = ContractGenerator.GenerateContractInterface(manifest, "Neo.Native");
+                var source = ContractGenerator.GenerateContractInterface(manifest, "Neo.Native", "");
                 await System.IO.File.WriteAllTextAsync($"./out/{manifest.Name}.cs", source);
             }
         }


### PR DESCRIPTION
* Add `InterfaceName` property for `NeoContractInterface` Task
* Allow developer to specify `ContractNameOverride` MSBuild item property to override generated contract interface name
* Enable developer to specify path to manifest file directly via <NeoContractInfo>
* `NeoContractInterface` fails if generated contract interface name isn't a valid C# type name

fix #27
fix #28