### PR TITLE
Pass .csproj file to NeoCsc Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ may not exactly match a publicly released version.
 
 ## [Unreleased]
 
+### Changed
+* Pass .csproj file instead of .cs sources to NeoCsc task due to [existing nccs issue](https://github.com/neo-project/neo-devpack-dotnet/issues/759) (#34)
+
 ### Fixed
 
-* `NeoContractInterface` fails if generated contract interface name isn't a valid C# type name
+* `NeoContractInterface` fails if generated contract interface name isn't a valid C# type name (#33)
+
 
 ## [3.3] - 2022-06-28
 

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -4,12 +4,12 @@
   <PropertyGroup>
     <NeoBuildTasksFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">netstandard2.0</NeoBuildTasksFolder>
     <NeoBuildTasksFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' ">net472</NeoBuildTasksFolder>
-    <NeoBuildTasksAssembly>$(MSBuildThisFileDirectory)..\tasks\$(NeoBuildTasksFolder)\neo-build-tasks.dll</NeoBuildTasksAssembly>
+    <_NeoBuildTasksAssemblyPath>$([MSBuild]::ValueOrDefault('$(NeoBuildTasksAssembly)', '$(MSBuildThisFileDirectory)..\tasks\$(NeoBuildTasksFolder)\neo-build-tasks.dll'))</_NeoBuildTasksAssemblyPath>
   </PropertyGroup>
 
-  <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoContractInterface"/>
-  <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoCsc"/>
-  <UsingTask AssemblyFile="$(NeoBuildTasksAssembly)" TaskName="Neo.BuildTasks.NeoExpressBatch"/>
+  <UsingTask AssemblyFile="$(_NeoBuildTasksAssemblyPath)" TaskName="Neo.BuildTasks.NeoContractInterface"/>
+  <UsingTask AssemblyFile="$(_NeoBuildTasksAssemblyPath)" TaskName="Neo.BuildTasks.NeoCsc"/>
+  <UsingTask AssemblyFile="$(_NeoBuildTasksAssemblyPath)" TaskName="Neo.BuildTasks.NeoExpressBatch"/>
 
   <Target Name="ConfigureNeoCsc">
     <PropertyGroup>

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -47,7 +47,7 @@
       Inline="$(NeoCscOptimize)"
       Optimize="$(NeoCscOptimize)"
       Output="$(NeoContractOutput)"
-      Sources="@(Compile)"
+      Sources="$(MSBuildProjectFullPath)"
       WorkingDirectory="$(MSBuildProjectDirectory)"/>
   </Target>
 

--- a/test/test-build-tasks/Extensions.cs
+++ b/test/test-build-tasks/Extensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Utilities.ProjectCreation;
+using Neo.BuildTasks;
+
+namespace build_tasks
+{
+    static class Extensions
+    {
+        public static void RunThrow(this IProcessRunner @this, string command, string arguments, string? workingDirectory = null)
+        {
+            var result = @this.Run(command, arguments, workingDirectory);
+            if (result.ExitCode != 0)
+            {
+                if (result.Error.Count == 1)
+                {
+                    throw new Exception(result.Error.Single());
+                }
+                else
+                {
+                    throw new AggregateException(result.Error.Select(e => new Exception(e)));
+                }
+            }
+        }
+
+        public static ProjectCreator ImportNeoBuildTools(this ProjectCreator @this)
+        {
+            var buildTasksPath = typeof(NeoCsc).Assembly.Location;
+            var testBuildAssmblyDirectory = Path.GetDirectoryName(typeof(TestBuild).Assembly.Location)
+                ?? throw new Exception("Couldn't get directory name of TestBuild assembly");
+            var targetsPath = Path.Combine(testBuildAssmblyDirectory, "build", "Neo.BuildTasks.targets");
+
+            return @this
+                .Property("NeoBuildTasksAssembly", buildTasksPath)
+                .Import(targetsPath);
+        }
+    }
+}

--- a/test/test-build-tasks/TestBuild.TestRootPath.cs
+++ b/test/test-build-tasks/TestBuild.TestRootPath.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+
+namespace build_tasks
+{
+    public partial class TestBuild
+    {
+        class TestRootPath : IDisposable
+        {
+            readonly string Value;
+
+            public TestRootPath()
+            {
+                Value = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                Directory.CreateDirectory(Value);
+            }
+
+            public void Dispose()
+            {
+                if (Directory.Exists(Value)) Directory.Delete(Value, true);
+            }
+
+            public static implicit operator string(TestRootPath p) => p.Value;
+        }
+
+    }
+}

--- a/test/test-build-tasks/TestBuild.cs
+++ b/test/test-build-tasks/TestBuild.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using Microsoft.Build.Utilities.ProjectCreation;
+using Neo.BuildTasks;
+using Xunit;
+
+namespace build_tasks
+{
+    public class TestBuild : MSBuildTestBase
+    {
+        static void InstallNccs(string path, string version = "3.3.0")
+        {
+            var runner = new ProcessRunner();
+            runner.RunThrow("dotnet", "new tool-manifest", path);
+            runner.RunThrow("dotnet", $"tool install neo.compiler.csharp --version {version}", path);
+        }
+
+        static void WriteSource(string path, string source, string filename = "contract.cs")
+        {
+            var fullPath = Path.Combine(path, filename);
+            File.WriteAllText(fullPath, source);
+        }
+
+        static ProjectCreator CreateContractProject(string rootPath, string source)
+        {
+            WriteSource(rootPath, source);
+            return ProjectCreator.Templates.SdkCsproj(
+                path: Path.Combine(rootPath, "test.csproj"),
+                targetFramework: "net6.0")
+                .Property("NeoContractName", "$(AssemblyName)")
+                .ImportNeoBuildTools()
+                .ItemPackageReference("Neo.SmartContract.Framework", version: "3.3.0");
+        }
+
+        static void TestBuildContract(string source)
+        {
+            var testRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            try
+            {
+                Directory.CreateDirectory(testRootPath);
+                InstallNccs(testRootPath);
+
+                WriteSource(testRootPath, source);
+
+                var creator = CreateContractProject(testRootPath, source);
+                creator.TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
+
+                Assert.True(result, string.Join('\n', buildOutput.Errors));
+            }
+            finally
+            {
+                if (Directory.Exists(testRootPath)) Directory.Delete(testRootPath, true);
+            }
+        }
+
+        [Fact]
+        public void can_build_contract_that_calls_assert_with_message()
+        {
+            const string source = @"
+using Neo.SmartContract.Framework;
+
+namespace BuildToolsTestClasses
+{
+    public class TestContract : SmartContract
+    {
+        public static void TestAssert() { ExecutionEngine.Assert(false, ""message""); }
+    }
+}";
+            TestBuildContract(source);
+        }
+
+        [Fact]
+        public void can_build_TokenContract()
+        {
+            const string source = @"
+using Neo.SmartContract.Framework;
+
+    public class TestContract : TokenContract
+    {
+        public override byte Decimals() => 0;
+        public override string Symbol() => ""TEST"";
+    }
+";
+            TestBuildContract(source);
+        }
+
+    }
+}

--- a/test/test-build-tasks/TestDotNetToolTask.cs
+++ b/test/test-build-tasks/TestDotNetToolTask.cs
@@ -1,20 +1,21 @@
 using System;
+using Microsoft.Build.Utilities.ProjectCreation;
 using Moq;
 using Neo.BuildTasks;
 using Xunit;
 
 namespace build_tasks
 {
-    public class TestDotNetToolTask
+    public class TestDotNetToolTask  : MSBuildTestBase
     {
         class TestTask : DotNetToolTask
         {
             protected override string Command => "nccs";
             protected override string PackageId => "Neo.Compiler.CSharp";
 
-            readonly Func<NugetPackageVersion, bool> validator;
+            readonly Func<NugetPackageVersion, bool>? validator;
 
-            public TestTask(IProcessRunner processRunner, Func<NugetPackageVersion, bool> validator = null) : base(processRunner)
+            public TestTask(IProcessRunner processRunner, Func<NugetPackageVersion, bool> ?validator = null) : base(processRunner)
             {
                 this.validator = validator;
             }

--- a/test/test-build-tasks/test-build-tasks.csproj
+++ b/test/test-build-tasks/test-build-tasks.csproj
@@ -2,27 +2,38 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
     <RootNamespace>build_tasks</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\src\build-tasks\build\**"
+          Link="build\%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\src\build-tasks\buildMultiTargeting\**"
+          Link="buildMultiTargeting\%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\build-tasks\build-tasks.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="moq" Version="4.18.1" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="MSBuild.ProjectCreation" Version="8.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\build-tasks\build-tasks.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Revert original 3.3 change to pass .cs sources to NeoCsc task due to https://github.com/neo-project/neo-devpack-dotnet/issues/759

fixes #32
