### PR TITLE
Fix Tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ env:
 
 jobs:
   build:
-    if: startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -36,6 +35,7 @@ jobs:
         name: packages
         path: ./out
     - name: Create Release
+      if: startsWith(github.ref, 'refs/heads/release/')
       uses: marvinpinto/action-automatic-releases@v1.1.1
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -45,10 +45,14 @@ jobs:
         files: |
           ./out/*
     - name: Push to Nuget.org
+      if: startsWith(github.ref, 'refs/heads/release/')
       run: dotnet nuget push ${{ format('./out/Neo.Assertions.{0}.nupkg', steps.nbgv.outputs.NuGetPackageVersion) }} --api-key ${{ secrets.NUGET_ORG_TOKEN }} --source https://api.nuget.org/v3/index.json
     - name: Push to Nuget.org
+      if: startsWith(github.ref, 'refs/heads/release/')
       run: dotnet nuget push ${{ format('./out/Neo.BuildTasks.{0}.nupkg', steps.nbgv.outputs.NuGetPackageVersion) }} --api-key ${{ secrets.NUGET_ORG_TOKEN }} --source https://api.nuget.org/v3/index.json
     - name: Push to Nuget.org
+      if: startsWith(github.ref, 'refs/heads/release/')
       run: dotnet nuget push ${{ format('./out/Neo.Test.Harness.{0}.nupkg', steps.nbgv.outputs.NuGetPackageVersion) }} --api-key ${{ secrets.NUGET_ORG_TOKEN }} --source https://api.nuget.org/v3/index.json
     - name: Push to Nuget.org
+      if: startsWith(github.ref, 'refs/heads/release/')
       run: dotnet nuget push ${{ format('./out/Neo.Test.Runner.{0}.nupkg', steps.nbgv.outputs.NuGetPackageVersion) }} --api-key ${{ secrets.NUGET_ORG_TOKEN }} --source https://api.nuget.org/v3/index.json

--- a/test/test-build-tasks/Extensions.cs
+++ b/test/test-build-tasks/Extensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Utilities.ProjectCreation;
@@ -53,7 +54,8 @@ namespace build_tasks
 
         public static ProjectCreator AssertBuild(this ProjectCreator @this, ITestOutputHelper? output = null)
         {
-            @this.TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
+            var globalProperties = new Dictionary<string, string>() { ["Configuration"] = "Debug" };
+            @this.TryBuild(restore: true, globalProperties, out bool result, out BuildOutput buildOutput);
             if (!result)
             {
                 if (output != null)
@@ -77,7 +79,7 @@ namespace build_tasks
         public static ProjectCreator ImportNeoBuildTools(this ProjectCreator @this)
         {
             var buildTasksPath = typeof(NeoCsc).Assembly.Location;
-            var testBuildAssmblyDirectory = Path.GetDirectoryName(typeof(TestBuild).Assembly.Location)
+            var testBuildAssmblyDirectory = Path.GetDirectoryName(typeof(TestMSBuild).Assembly.Location)
                 ?? throw new Exception("Couldn't get directory name of TestBuild assembly");
             var targetsPath = Path.Combine(testBuildAssmblyDirectory, "build", "Neo.BuildTasks.targets");
 

--- a/test/test-build-tasks/TestBuild.cs
+++ b/test/test-build-tasks/TestBuild.cs
@@ -95,6 +95,11 @@ using Neo.SmartContract.Framework;
                 .AssertBuild(output);
 
             var generatedCodePath = Path.Combine(testRootPath, "obj/Debug/net6.0/registrar.contract-interface.cs");
+            output.WriteLine($"generatedCodePath: {generatedCodePath}");
+            foreach (var file in Directory.EnumerateFiles(generatedCodePath, "", SearchOption.AllDirectories))
+            {
+                output.WriteLine(file);
+            }
             Assert.True(File.Exists(generatedCodePath), "contract interface not generated");
         }
 
@@ -141,6 +146,11 @@ using Neo.SmartContract.Framework;
                 .AssertBuild(output);
 
             var generatedCodePath = Path.Combine(testRootPath, "test/obj/Debug/net6.0/registrar.contract-interface.cs");
+            output.WriteLine($"generatedCodePath: {generatedCodePath}");
+            foreach (var file in Directory.EnumerateFiles(generatedCodePath, "", SearchOption.AllDirectories))
+            {
+                output.WriteLine(file);
+            }
             Assert.True(File.Exists(generatedCodePath), "contract interface not generated");
         }
 

--- a/test/test-build-tasks/TestBuild.cs
+++ b/test/test-build-tasks/TestBuild.cs
@@ -96,7 +96,7 @@ using Neo.SmartContract.Framework;
 
             var generatedCodePath = Path.Combine(testRootPath, "obj/Debug/net6.0/registrar.contract-interface.cs");
             output.WriteLine($"generatedCodePath: {generatedCodePath}");
-            foreach (var file in Directory.EnumerateFiles(generatedCodePath, "", SearchOption.AllDirectories))
+            foreach (var file in Directory.EnumerateFiles(testRootPath, "", SearchOption.AllDirectories))
             {
                 output.WriteLine(file);
             }
@@ -147,7 +147,7 @@ using Neo.SmartContract.Framework;
 
             var generatedCodePath = Path.Combine(testRootPath, "test/obj/Debug/net6.0/registrar.contract-interface.cs");
             output.WriteLine($"generatedCodePath: {generatedCodePath}");
-            foreach (var file in Directory.EnumerateFiles(generatedCodePath, "", SearchOption.AllDirectories))
+            foreach (var file in Directory.EnumerateFiles(testRootPath, "", SearchOption.AllDirectories))
             {
                 output.WriteLine(file);
             }

--- a/test/test-build-tasks/TestMSBuild.TestRootPath.cs
+++ b/test/test-build-tasks/TestMSBuild.TestRootPath.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace build_tasks
 {
-    public partial class TestBuild
+    public partial class TestMSBuild
     {
         internal class TestRootPath : IDisposable
         {

--- a/test/test-build-tasks/TestMSBuild.cs
+++ b/test/test-build-tasks/TestMSBuild.cs
@@ -7,11 +7,11 @@ using Xunit.Abstractions;
 
 namespace build_tasks
 {
-    public partial class TestBuild : MSBuildTestBase
+    public partial class TestMSBuild : MSBuildTestBase
     {
         readonly ITestOutputHelper output;
 
-        public TestBuild(ITestOutputHelper output)
+        public TestMSBuild(ITestOutputHelper output)
         {
             this.output = output;
         }
@@ -94,13 +94,7 @@ using Neo.SmartContract.Framework;
                 .ItemInclude("NeoContractGeneration", "registrar", metadata: metadata)
                 .AssertBuild(output);
 
-            var generatedCodePath = Path.Combine(testRootPath, "obj/Debug/net6.0/registrar.contract-interface.cs");
-            output.WriteLine($"generatedCodePath: {generatedCodePath}");
-            foreach (var file in Directory.EnumerateFiles(testRootPath, "", SearchOption.AllDirectories))
-            {
-                output.WriteLine(file);
-            }
-            Assert.True(File.Exists(generatedCodePath), "contract interface not generated");
+            CheckGeneratedPath(testRootPath, "obj/Debug/net6.0/registrar.contract-interface.cs");
         }
 
         [Fact]
@@ -145,13 +139,20 @@ using Neo.SmartContract.Framework;
                 .ItemInclude("NeoContractReference", srcCreator.FullPath, metadata: metadata)
                 .AssertBuild(output);
 
-            var generatedCodePath = Path.Combine(testRootPath, "test/obj/Debug/net6.0/registrar.contract-interface.cs");
-            output.WriteLine($"generatedCodePath: {generatedCodePath}");
-            foreach (var file in Directory.EnumerateFiles(testRootPath, "", SearchOption.AllDirectories))
+            CheckGeneratedPath(testRootPath, "test/obj/Debug/net6.0/registrar.contract-interface.cs");
+        }
+
+        void CheckGeneratedPath(string testRootPath, string relativeGeneratedPath)
+        {
+            var generatedCodePath = Path.Combine(testRootPath, relativeGeneratedPath);
+            if (!File.Exists(generatedCodePath))
             {
-                output.WriteLine(file);
+                foreach (var file in Directory.EnumerateFiles(testRootPath, "", SearchOption.AllDirectories))
+                {
+                    output.WriteLine(file);
+                }
+                throw new FileNotFoundException("contract interface not generated", generatedCodePath);
             }
-            Assert.True(File.Exists(generatedCodePath), "contract interface not generated");
         }
 
         public static ProjectCreator CreateDotNetSixProject(string directory, string projectName = "project.csproj")


### PR DESCRIPTION
Force msbuild tests to always build debug so generated contract interface is always in the same location