### PR TITLE
generate debug info by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ will not have contiguous patch numbers. Initial major and minor releases will be
 in this file without a patch number. Patch version will be included for bug fixes, but
 may not exactly match a publicly released version.
 
+## [Unreleased]
+
+### Changed
+* Always generate debug info, regardless of configuration property, unless `NeoCscDebugInfo` property is false (#37)
+
+
 ## [3.3.23] - 2022-07-06
 
 ### Added

--- a/src/build-tasks/build/Neo.BuildTasks.targets
+++ b/src/build-tasks/build/Neo.BuildTasks.targets
@@ -23,14 +23,13 @@
 
       <NeoCscOptimize>true</NeoCscOptimize>
       <NeoCscOptimize Condition="'$(Configuration)'=='Debug'">false</NeoCscOptimize>
-      <NeoCscDebug>false</NeoCscDebug>
-      <NeoCscDebug Condition="'$(Configuration)'=='Debug'">true</NeoCscDebug>
+      <NeoCscDebugInfo Condition="'$(NeoCscDebugInfo)'==''">true</NeoCscDebugInfo>
     </PropertyGroup>
 
     <ItemGroup>
       <NeoCscOutput Include="$(NeoCscContractPath)" />
       <NeoCscOutput Include="$(NeoCscManifestPath)" />
-      <NeoCscOutput Include="$(NeoCscDebugInfoPath)" Condition="'$(NeoCscDebug)'=='true'" />
+      <NeoCscOutput Include="$(NeoCscDebugInfoPath)" Condition="'$(NeoCscDebugInfo)'=='true'" />
       <NeoCscOutput Include="$(NeoCscAssemblyPath)" Condition="'$(NeoContractAssembly)'=='true'"/>
     </ItemGroup>
   </Target>
@@ -43,7 +42,7 @@
     <NeoCsc 
       Assembly="$(NeoContractAssembly)"
       BaseFileName="$(NeoContractName)"
-      Debug="$(NeoCscDebug)"
+      Debug="$(NeoCscDebugInfo)"
       Inline="$(NeoCscOptimize)"
       Optimize="$(NeoCscOptimize)"
       Output="$(NeoContractOutput)"

--- a/test/test-build-tasks/test-build-tasks.csproj
+++ b/test/test-build-tasks/test-build-tasks.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="MSBuild.ProjectCreation" Version="8.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.Combinatorial" Version="1.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
* Always generate debug info by default, regardless of config. 
* Manual control of debug info via `NeoCscDebugInfo` property